### PR TITLE
ACC-71: Allow to deploy PLF on JBoss EAP 7.0

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -1111,7 +1111,19 @@ do_start() {
       ${DEPLOYMENT_DIR}/${DEPLOYMENT_SERVER_SCRIPT} start
     ;;
     jbosseap)
-      END_STARTUP_MSG="JBAS01587[45]"
+      case ${DEPLOYMENT_APPSRV_VERSION:0:1} in
+        6)
+          END_STARTUP_MSG="JBAS01587[45]"
+        ;;
+        7)
+          END_STARTUP_MSG="WFLYSRV0025"
+        ;;
+        *)
+          echo_error "Invalid JBoss EAP server version \"${DEPLOYMENT_APPSRV_VERSION}\""
+          print_usage
+          exit 1
+        ;;
+      esac
       # Additional settings
       export JAVA_OPTS="${DEPLOYMENT_OPTS}"
       # Startup the server
@@ -1193,7 +1205,19 @@ do_stop() {
           ${DEPLOYMENT_DIR}/${DEPLOYMENT_SERVER_SCRIPT} stop 60 -force > /dev/null 2>&1 || true
         ;;
         jbosseap)
-          ${DEPLOYMENT_DIR}/bin/jboss-cli.sh --controller=localhost:${DEPLOYMENT_MGT_NATIVE_PORT} --connect command=:shutdown > /dev/null 2>&1 || true
+          case ${DEPLOYMENT_APPSRV_VERSION:0:1} in
+            6)
+              ${DEPLOYMENT_DIR}/bin/jboss-cli.sh --controller=localhost:${DEPLOYMENT_MGT_NATIVE_PORT} --connect command=:shutdown > /dev/null 2>&1 || true
+            ;;
+            7)
+              ${DEPLOYMENT_DIR}/bin/jboss-cli.sh --controller=localhost:${DEPLOYMENT_MGT_HTTP_PORT} --connect --command=shutdown > /dev/null 2>&1 || true
+            ;;
+            *)
+              echo_error "Invalid JBoss EAP server version \"${DEPLOYMENT_APPSRV_VERSION}\""
+              print_usage
+              exit 1
+            ;;
+          esac
           echo_n_info "Waiting for shutdown "
           while [ -e ${DEPLOYMENT_PID_FILE} ];
           do

--- a/etc/jbosseap7/standalone-exo-mysql.xml.patch
+++ b/etc/jbosseap7/standalone-exo-mysql.xml.patch
@@ -1,0 +1,158 @@
+--- /tmp/standalone-exo.xml
++++ /tmp/patchs/standalone-exo-mysql.xml
+@@ -202,15 +202,17 @@
+                 <!-- eXo IDM Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.mysql.jdbc.Driver</driver-class>
+-                    <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
+-                    -->
++                    <connection-url>jdbc:mysql://@DB_IDM_HOST@:@DB_IDM_PORT@/@DB_IDM_NAME@?autoReconnect=true</connection-url>
++
+                     <!-- PostgreSQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -256,8 +258,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_IDM_USR@</user-name>
++                        <password>@DB_IDM_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -265,14 +267,16 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- PostgreSQL and Enterprise DB PostgreSQL Plus Advanced server -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />
+@@ -312,15 +316,17 @@
+                 <!-- eXo JCR Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jcr_portal" jta="false" pool-name="exo-jcr_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.mysql.jdbc.Driver</driver-class>
+-                    <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
+-                    -->
++                    <connection-url>jdbc:mysql://@DB_JCR_HOST@:@DB_JCR_PORT@/@DB_JCR_NAME@?autoReconnect=true</connection-url>
++
+                     <!-- PostgreSQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -366,8 +372,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JCR_USR@</user-name>
++                        <password>@DB_JCR_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -375,14 +381,16 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- PostgreSQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />
+@@ -422,15 +430,17 @@
+                 <!-- eXo JPA Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jpa_portal" jta="false" pool-name="exo-jpa_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.mysql.jdbc.Driver</driver-class>
+-                    <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true&amp;characterEncoding=utf8</connection-url>
+-                    -->
++                    <connection-url>jdbc:mysql://@DB_JPA_HOST@:@DB_JPA_PORT@/@DB_JPA_NAME@?autoReconnect=true&amp;characterEncoding=utf8</connection-url>
++
+                     <!-- PostgreSQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -476,8 +486,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JPA_USR@</user-name>
++                        <password>@DB_JPA_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -485,14 +495,16 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- PostgreSQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />

--- a/etc/jbosseap7/standalone-exo-oracle.xml.patch
+++ b/etc/jbosseap7/standalone-exo-oracle.xml.patch
@@ -1,0 +1,197 @@
+--- standalone-exo.xml
++++ standalone-exo-oracle.xml
+@@ -202,9 +202,11 @@
+                 <!-- eXo IDM Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -224,11 +226,11 @@
+                     <connection-url>jdbc:edb://localhost:5432/plf</connection-url>
+                     -->
+                     <!-- Oracle -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>oracle.jdbc.OracleDriver</driver-class>
+-                    <connection-url>jdbc:oracle:thin:@localhost:1521:plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:oracle:thin:@@DB_IDM_HOST@:@DB_IDM_PORT@:@DB_IDM_NAME@</connection-url>
++
+                     <!-- Sybase -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -256,8 +258,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_IDM_USR@</user-name>
++                        <password>@DB_IDM_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -265,9 +267,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -279,11 +283,11 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+                           -->
+                         <!-- Oracle -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker" />
+-                          -->
++
+                         <!-- Sybase -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseExceptionSorter" />
+@@ -312,9 +316,11 @@
+                 <!-- eXo JCR Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jcr_portal" jta="false" pool-name="exo-jcr_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -334,11 +340,11 @@
+                     <connection-url>jdbc:edb://localhost:5432/plf</connection-url>
+                     -->
+                     <!-- Oracle -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>oracle.jdbc.OracleDriver</driver-class>
+-                    <connection-url>jdbc:oracle:thin:@localhost:1521:plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:oracle:thin:@@DB_JCR_HOST@:@DB_JCR_PORT@:@DB_JCR_NAME@</connection-url>
++
+                     <!-- Sybase -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -366,8 +372,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JCR_USR@</user-name>
++                        <password>@DB_JCR_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -375,9 +381,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -389,11 +397,11 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+                           -->
+                         <!-- Oracle -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker" />
+-                          -->
++
+                         <!-- Sybase -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseExceptionSorter" />
+@@ -422,9 +430,11 @@
+                 <!-- eXo JPA Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jpa_portal" jta="false" pool-name="exo-jpa_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -444,11 +454,11 @@
+                     <connection-url>jdbc:edb://localhost:5432/plf</connection-url>
+                     -->
+                     <!-- Oracle -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>oracle.jdbc.OracleDriver</driver-class>
+-                    <connection-url>jdbc:oracle:thin:@localhost:1521:plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:oracle:thin:@@DB_JPA_HOST@:@DB_JPA_PORT@:@DB_IDM_NAME@</connection-url>
++
+                     <!-- Sybase -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -476,8 +486,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JPA_USR@</user-name>
++                        <password>@DB_JPA_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -485,9 +495,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -499,11 +511,11 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+                           -->
+                         <!-- Oracle -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker" />
+-                          -->
++
+                         <!-- Sybase -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseExceptionSorter" />

--- a/etc/jbosseap7/standalone-exo-ports.xml.patch
+++ b/etc/jbosseap7/standalone-exo-ports.xml.patch
@@ -1,0 +1,31 @@
+--- /tmp/standalone-exo.xml
++++ /tmp/patchs/standalone-exo-ports.xml
+@@ -751,6 +751,7 @@
+         <subsystem xmlns="urn:jboss:domain:undertow:3.1">
+             <buffer-cache name="default"/>
+             <server name="default-server">
++                <ajp-listener name="ajp" socket-binding="ajp"/>
+                 <http-listener name="default" socket-binding="http" redirect-socket="https"/>
+                 <host name="default-host" alias="localhost">
+                     <location name="/" handler="exoplatform-welcome-content"/>
+@@ -794,13 +795,13 @@
+         </interface>
+     </interfaces>
+     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+-        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+-        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+-        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+-        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+-        <socket-binding name="txn-recovery-environment" port="4712"/>
+-        <socket-binding name="txn-status-manager" port="4713"/>
++        <socket-binding name="management-http" interface="management" port="@MGT_HTTP_PORT@"/>
++        <socket-binding name="management-https" interface="management" port="@MGT_HTTPS_PORT@"/>
++        <socket-binding name="ajp" port="@AJP_PORT@"/>
++        <socket-binding name="http" port="@HTTP_PORT@"/>
++        <socket-binding name="https" port="@HTTPS_PORT@"/>
++        <socket-binding name="txn-recovery-environment" port="@TXN_RECOVERY_ENV_PORT@"/>
++        <socket-binding name="txn-status-manager" port="@TXN_STATUS_MGR_PORT@"/>
+         <outbound-socket-binding name="mail-smtp">
+             <remote-destination host="localhost" port="25"/>
+         </outbound-socket-binding>

--- a/etc/jbosseap7/standalone-exo-postgres.xml.patch
+++ b/etc/jbosseap7/standalone-exo-postgres.xml.patch
@@ -1,0 +1,191 @@
+--- /tmp/standalone-exo.xml
++++ /tmp/patchs/standalone-exo-postgres.xml
+@@ -202,9 +202,11 @@
+                 <!-- eXo IDM Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -212,11 +214,11 @@
+                     <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
+                     -->
+                     <!-- PostgreSQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>org.postgresql.Driver</driver-class>
+-                    <connection-url>jdbc:postgresql://localhost:5432/plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:postgresql://@DB_IDM_HOST@:@DB_IDM_PORT@/@DB_IDM_NAME@</connection-url>
++
+                     <!-- Enterprise DB PostgreSQL Plus Advanced server -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -256,8 +258,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_IDM_USR@</user-name>
++                        <password>@DB_IDM_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -265,19 +267,21 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+                           -->
+                         <!-- PostgreSQL and Enterprise DB PostgreSQL Plus Advanced server -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- Oracle -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+@@ -312,9 +316,11 @@
+                 <!-- eXo JCR Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jcr_portal" jta="false" pool-name="exo-jcr_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -322,11 +328,11 @@
+                     <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
+                     -->
+                     <!-- PostgreSQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>org.postgresql.Driver</driver-class>
+-                    <connection-url>jdbc:postgresql://localhost:5432/plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:postgresql://@DB_JCR_HOST@:@DB_JCR_PORT@/@DB_JCR_NAME@</connection-url>
++
+                     <!-- Enterprise DB PostgreSQL Plus Advanced server -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -366,8 +372,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JCR_USR@</user-name>
++                        <password>@DB_JCR_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -375,19 +381,21 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+                           -->
+                         <!-- PostgreSQL -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- Oracle -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+@@ -422,9 +430,11 @@
+                 <!-- eXo JPA Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jpa_portal" jta="false" pool-name="exo-jpa_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -432,11 +442,11 @@
+                     <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true&amp;characterEncoding=utf8</connection-url>
+                     -->
+                     <!-- PostgreSQL -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>org.postgresql.Driver</driver-class>
+-                    <connection-url>jdbc:postgresql://localhost:5432/plf</connection-url>
+-                    -->
++                    <connection-url>jdbc:postgresql://@DB_JPA_HOST@:@DB_JPA_PORT@/@DB_IDM_NAME@</connection-url>
++
+                     <!-- Enterprise DB PostgreSQL Plus Advanced server -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -476,8 +486,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JPA_USR@</user-name>
++                        <password>@DB_JPA_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -485,19 +495,21 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
+                           -->
+                         <!-- PostgreSQL -->
+-                        <!--
++
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter" />
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- Oracle -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />

--- a/etc/jbosseap7/standalone-exo-sqlserver.xml.patch
+++ b/etc/jbosseap7/standalone-exo-sqlserver.xml.patch
@@ -1,0 +1,191 @@
+--- /tmp/standalone-exo.xml
++++ /tmp/patchs/standalone-exo-sqlserver.xml
+@@ -202,9 +202,11 @@
+                 <!-- eXo IDM Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -236,11 +238,11 @@
+                     <connection-url>jdbc:sybase:Tds:localhost:5000</connection-url>
+                     -->
+                     <!-- Microsoft SQLServer -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.microsoft.sqlserver.jdbc.SQLServerDriver</driver-class>
+-                    <connection-url>jdbc:sqlserver://localhost:1433;databaseName=plf;sendStringParametersAsUnicode=false</connection-url>
+-                    -->
++                    <connection-url>jdbc:sqlserver://@DB_IDM_HOST@:@DB_IDM_PORT@;databaseName=@DB_IDM_NAME@;sendStringParametersAsUnicode=false</connection-url>
++
+                     <!-- IBM DB2 -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -256,8 +258,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_IDM_USR@</user-name>
++                        <password>@DB_IDM_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -265,9 +267,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -290,9 +294,9 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseValidConnectionChecker" />
+                           -->
+                         <!-- Microsoft SQLServer -->
+-                        <!--
++
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- IBM DB2 -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.db2.DB2ExceptionSorter" />
+@@ -312,9 +316,11 @@
+                 <!-- eXo JCR Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jcr_portal" jta="false" pool-name="exo-jcr_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -346,11 +352,11 @@
+                     <connection-url>jdbc:sybase:Tds:localhost:5000</connection-url>
+                     -->
+                     <!-- Microsoft SQLServer -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.microsoft.sqlserver.jdbc.SQLServerDriver</driver-class>
+-                    <connection-url>jdbc:sqlserver://localhost:1433;databaseName=plf;sendStringParametersAsUnicode=false</connection-url>
+-                    -->
++                    <connection-url>jdbc:sqlserver://@DB_JCR_HOST@:@DB_JCR_PORT@;databaseName=@DB_JCR_NAME@;sendStringParametersAsUnicode=false</connection-url>
++
+                     <!-- IBM DB2 -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -366,8 +372,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JCR_USR@</user-name>
++                        <password>@DB_JCR_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -375,9 +381,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -400,9 +408,9 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseValidConnectionChecker" />
+                           -->
+                         <!-- Microsoft SQLServer -->
+-                        <!--
++
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- IBM DB2 -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.db2.DB2ExceptionSorter" />
+@@ -422,9 +430,11 @@
+                 <!-- eXo JPA Datasource for PLF -->
+                 <datasource enabled="true" jndi-name="java:/comp/env/exo-jpa_portal" jta="false" pool-name="exo-jpa_portal" spy="false" use-ccm="true" use-java-context="true">
+                     <!-- HSQLDB -->
++                    <!--
+                     <driver>hsqldb-driver.jar</driver>
+                     <driver-class>org.hsqldb.jdbcDriver</driver-class>
+                     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
++                    -->
+                     <!-- MySQL -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -456,11 +466,11 @@
+                     <connection-url>jdbc:sybase:Tds:localhost:5000</connection-url>
+                     -->
+                     <!-- Microsoft SQLServer -->
+-                    <!--
+-                    <driver>XXXX.jar</driver>
++
++                    <driver>@DB_DRIVER@</driver>
+                     <driver-class>com.microsoft.sqlserver.jdbc.SQLServerDriver</driver-class>
+-                    <connection-url>jdbc:sqlserver://localhost:1433;databaseName=plf;sendStringParametersAsUnicode=true</connection-url>
+-                    -->
++                    <connection-url>jdbc:sqlserver://@DB_JPA_HOST@:@DB_JPA_PORT@;databaseName=@DB_JPA_NAME@;sendStringParametersAsUnicode=false</connection-url>
++
+                     <!-- IBM DB2 -->
+                     <!--
+                     <driver>XXXX.jar</driver>
+@@ -476,8 +486,8 @@
+                         <flush-strategy>FailingConnectionOnly</flush-strategy>
+                     </pool>
+                     <security>
+-                        <user-name>sa</user-name>
+-                        <password/>
++                        <user-name>@DB_JPA_USR@</user-name>
++                        <password>@DB_JPA_PWD@</password>
+                     </security>
+                     <validation>
+                         <validate-on-match>false</validate-on-match>
+@@ -485,9 +495,11 @@
+                         <background-validation-millis>60000</background-validation-millis>
+                         <use-fast-fail>false</use-fast-fail>
+                         <!-- Generic -->
++                        <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"/>
+                         <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker"/>
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.novendor.JDBC4ValidConnectionChecker"/>
++                        -->
+                         <!-- MySQL -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
+@@ -510,9 +522,9 @@
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.sybase.SybaseValidConnectionChecker" />
+                           -->
+                         <!-- Microsoft SQLServer -->
+-                        <!--
++
+                         <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mssql.MSSQLValidConnectionChecker" />
+-                          -->
++
+                         <!-- IBM DB2 -->
+                         <!--
+                         <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.db2.DB2ExceptionSorter" />


### PR DESCRIPTION
This PR contains the configuration files and updates to be able to deploy PLF 5.0.x on JBoss EAP 7:

- [x] `etc/jbosseap7/standalone-exo-XXX.xml.patch` files for MySQL, Oracle, Postgres and SQL Server databases
- [x]  `etc/jbosseap7/standalone-exo-ports.xml.patch` to be able to customize HTTP, AJP... 
- [x]  adt is now able to detect if EAP6 or EAP7 is started
In order to know if the server is started, adt looks for a key in the logs, this key has changed (from JBAS01587 to ***WFLYSRV0025***) because the embedded web server is now WildFly

**IMPORTANT: AJP**
The file `etc/jbosseap7/standalone-exo-ports.xml.patch` updates port and **adds a new line** 
`<ajp-listener name="ajp" socket-binding="ajp"/>` so that the connection between Apache and EAP 7 can be established.
This configuration was not required in `standalone-exo.xml` file with EAP6.

**NOTE ABOUT ulimit error**
PLF Acceptance instances deployed on EAP 7 have these errors:

```
2017-03-31 17:23:47,267 ERROR [io.undertow] (MSC service thread 1-7) UT005024: Could not register resource change listener for caching resource manager, automatic invalidation of cached resource will not work: java.lang.RuntimeException: java.io.IOException: User limit of inotify instances reached or too many open files
	at org.xnio.nio.WatchServiceFileSystemWatcher.<init>(WatchServiceFileSystemWatcher.java:75)
	at org.xnio.nio.NioXnio.createFileSystemWatcher(NioXnio.java:211)
	at io.undertow.server.handlers.resource.PathResourceManager.registerResourceChangeListener(PathResourceManager.java:190)
	at org.wildfly.extension.undertow.deployment.ServletResourceManager.registerResourceChangeListener(ServletResourceManager.java:82)
	at io.undertow.server.handlers.resource.CachingResourceManager.<init>(CachingResourceManager.java:64)
	at org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService.createServletConfig(UndertowDeploymentInfoService.java:584)
	at org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService.start(UndertowDeploymentInfoService.java:283)
	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: User limit of inotify instances reached or too many open files
	at sun.nio.fs.LinuxWatchService.<init>(LinuxWatchService.java:64)
	at sun.nio.fs.LinuxFileSystem.newWatchService(LinuxFileSystem.java:47)
	at org.xnio.nio.WatchServiceFileSystemWatcher.<init>(WatchServiceFileSystemWatcher.java:73)
	... 11 more
```
It seems to be related to the file system watch on exploded archive:
- https://issues.jboss.org/browse/WFLY-6251
- https://issues.jboss.org/browse/JBEAP-5079

The `platform.ear` archive is exploded in EAP7.
This configuration has been tested on Acceptance instance without success with EAP 7.0.0:
`DEPLOYMENT_OPTS="-Dio.undertow.disable-file-system-watcher=true" `