### PR TITLE
ACC-73: Configure UMASK value for Tomcat deployments

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -923,6 +923,7 @@ do_deploy() {
   configurable_env_var "DEPLOYMENT_LDAP_ADMIN_DN" ""
   configurable_env_var "DEPLOYMENT_LDAP_ADMIN_PWD" ""
   configurable_env_var "DEPLOYMENT_PORT_PREFIX" "80"
+  configurable_env_var "DEPLOYMENT_UMASK_VALUE" "0002"
   if ${DEPLOYMENT_CHAT_ENABLED}; then
     validate_env_var "DEPLOYMENT_CHAT_WEEMO_KEY"
   fi

--- a/etc/plf/setenv-local.sh
+++ b/etc/plf/setenv-local.sh
@@ -23,6 +23,8 @@
 # -----------------------------------------------------------------------------
 CATALINA_HOME="${DEPLOYMENT_DIR}"
 CATALINA_PID="${DEPLOYMENT_PID_FILE}"
+# ACC-73: Tomcat 8.5 restricted file permissions by updating UMASK default value
+UMASK="${DEPLOYMENT_UMASK_VALUE}"
 # Logs
 export EXO_LOGS_DISPLAY_CONSOLE=true
 export EXO_LOGS_COLORIZED_CONSOLE=true


### PR DESCRIPTION
Since **Tomcat 8.5** the file permissions have changed.
Now Tomcat sets **UMASK** to `0027` unless it has been overridden:
- https://github.com/apache/tomcat85/commit/bcbbe9060438076df5dbf6d1450b65370688aca2

This PR creates a `DEPLOYMENT_UMASK_VALUE` variable with `0002` as default value to have the same behavior than other Tomcat version.
It's a **configurable_env_var**, so this default value can be overridden in Jenkins Acceptance jobs.