### PR TITLE
ACC-60: Compare Translation branches with correct base branch

### DIFF
--- a/_functions_git.sh
+++ b/_functions_git.sh
@@ -36,13 +36,27 @@ clone_or_fetch_git_repo() {
     echo_info "Cloning repository ${_repo} into ${_src_dir} ..."
     git clone -v git@github.com:/${_orga}/${_repo}.git ${_src_dir}/${_repo}.git
     echo_info "Clone done ..."
+
+    # Add remote named blessed for exoplatform organization
+    pushd ${_src_dir}/${_repo}.git > /dev/null 2>&1
+    echo_info "Add blessed remote for exoplatform organization..."
+    git remote add blessed git@github.com:exoplatform/${_repo}.git
   else
     pushd ${_src_dir}/${_repo}.git > /dev/null 2>&1
     set +e
     status=0
     git remote set-url origin git@github.com:${_orga}/${_repo}.git
+    # Add remote named blessed for exoplatform organization
+    git ls-remote --exit-code blessed > /dev/null 2>&1
+    status=$?
+    set -e
+    if [ ${status} -ne 0 ]; then
+      echo_info "Add blessed remote for exoplatform organization..."
+      git remote add blessed git@github.com:exoplatform/${_repo}.git
+    fi
+    set +e
     echo_info "Updating repository ${_repo} in ${_src_dir} ..."
-    git fetch --progress --prune origin
+    git remote update --prune
     status=$?
     set -e
     if [ ${status} -ne 0 ]; then
@@ -54,7 +68,16 @@ clone_or_fetch_git_repo() {
       git clone -v git@github.com:/${_orga}/${_repo}.git ${_src_dir}/${_repo}.git
       echo_info "Clone done ..."
       pushd ${_src_dir}/${_repo}.git > /dev/null 2>&1
-      git fetch --progress --prune origin
+      set +e
+      # Add remote named blessed for exoplatform organization if it doesn't exist
+      git ls-remote --exit-code blessed > /dev/null 2>&1
+      status=$?
+      set -e
+      if [ ${status} -ne 0 ]; then
+        echo_info "Add blessed remote for exoplatform organization..."
+        git remote add blessed git@github.com:exoplatform/${_repo}.git
+      fi
+      git remote update --prune
     fi
     echo_info "Update done ..."
     popd > /dev/null 2>&1

--- a/adt.sh
+++ b/adt.sh
@@ -71,7 +71,7 @@ env_var "INSTANCES_CONF_DIR" "${ADT_DATA}/conf/instances"
 env_var "ETC_DIR" "${ADT_DATA}/etc"
 
 env_var "CURR_DATE" `date -u "+%Y%m%d.%H%M%S"`
-env_var "REPOS_LIST" "exoplatform:gatein-dep exodev:gatein-wci exodev:kernel exodev:core exodev:ws exodev:jcr exodev:gatein-sso exodev:gatein-pc exodev:gatein-portal exoplatform:maven-depmgt-pom exodev:docs-style exodev:platform-ui exodev:commons exodev:calendar exodev:forum exodev:wiki exodev:social exodev:ecms exodev:integration exodev:platform exodev:ide exoplatform:platform-public-distributions exoplatform:platform-private-trial-distributions exoplatform:platform-private-distributions"
+env_var "REPOS_LIST" "exoplatform:gatein-dep exodev:gatein-wci exodev:kernel exodev:core exodev:ws exodev:jcr exodev:gatein-sso exodev:gatein-pc exodev:gatein-portal exoplatform:maven-depmgt-pom exodev:docs-style exodev:platform-ui exodev:commons exodev:calendar exodev:forum exodev:wiki exodev:social exodev:ecms exodev:integration exodev:platform exoplatform:platform-public-distributions exoplatform:platform-private-trial-distributions exoplatform:platform-private-distributions"
 
 if ${ADT_DEV_MODE}; then
   configurable_env_var "ACCEPTANCE_SCHEME"  "http"


### PR DESCRIPTION
 The translation branches for released PLF versions are now compared with stable/X.Y.x instead of develop

   * update shell function clone_or_fetch_git_repo to add blessed remote on all cloned repositories
   * update PHP function getTranslationBranches to compare branches on exoplatform or exodev organization