### PR TITLE
ACC-86 : Use the right jdbc driver per version

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -229,11 +229,8 @@ initialize_product_settings() {
       env_var "DEPLOYMENT_SERVER_SCRIPT" "bin/gatein.sh"
       env_var "DEPLOYMENT_SERVER_LOG_FILE" "catalina.out"
       env_var "DEPLOYMENT_APPSRV_TYPE" "tomcat" #Server type
-      env_var "DEPLOYMENT_MYSQL_DRIVER_VERSION" "5.1.25" #Default version used to download additional mysql driver
-      env_var "DEPLOYMENT_POSTGRESQL_DRIVER_VERSION" "9.4.1208" #Default version used to download additional postgresql driver
-      env_var "DEPLOYMENT_ORACLE_DRIVER_VERSION" "12.1.0.1"
-      env_var "DEPLOYMENT_SQLSERVER_DRIVER_VERSION" "4.0.2206.100"
-      env_var "DEPLOYMENT_ADDONS_MANAGER_VERSION" "1.0.0-RC4" #Add-ons Manager to use
+
+      env_var "DEPLOYMENT_ADDONS_MANAGER_VERSION" "1.0.0-RC4" #Add-ons Manager to use      
 
       configurable_env_var "REPOSITORY_SERVER_BASE_URL" "https://repository.exoplatform.org"
       configurable_env_var "REPOSITORY_USERNAME" ""
@@ -600,6 +597,39 @@ initialize_product_settings() {
         env_var "INSTANCE_DESCRIPTION" "${PRODUCT_DESCRIPTION} ${PRODUCT_VERSION}"
       else
         env_var "INSTANCE_DESCRIPTION" "${PRODUCT_DESCRIPTION} ${PRODUCT_VERSION} (${INSTANCE_ID})"
+      fi
+
+      if [[ "${PRODUCT_NAME}" =~ ^(plf) ]]; then
+        # specific configuration for plf deployments
+        # - Database drivers
+        # - TODO add DEPLOYMENT_APPSRV_VERSION
+        if [[ "${PRODUCT_BRANCH}" =~ ^(5.0) ]]; then
+          env_var "DEPLOYMENT_FORCE_JDBC_DRIVER_ADDON" "true"
+          env_var "DEPLOYMENT_MYSQL_ADDON_VERSION" "1.1.0" # Default version of the mysql driver addon to use
+          env_var "DEPLOYMENT_MYSQL_DRIVER_VERSION" "5.1.44" #Default version used to download additional mysql driver
+          env_var "DEPLOYMENT_POSTGRESQL_ADDON_VERSION" "1.1.0" # Default version of the jdbc postgresql driver addon to use
+          env_var "DEPLOYMENT_POSTGRESQL_DRIVER_VERSION" "42.1.4" #Default version used to download additional postgresql driver
+          env_var "DEPLOYMENT_ORACLE_ADDON_VERSION" "1.1.0" # Default version of the oracle jdbc driver addon to use
+          env_var "DEPLOYMENT_ORACLE_DRIVER_VERSION" "12.2.0.1"
+          env_var "DEPLOYMENT_SQLSERVER_ADDON_VERSION" "1.1.0" # Default version of the sqlserver jdbc driver addon to use
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_GROUPID" "com.microsoft.sqlserver"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_ARTIFACTID" "mssql-jdbc"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_REPO" "public"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_VERSION" "6.2.2.jre8"
+        elif [[ "${PRODUCT_BRANCH}" =~ ^([43]) ]]; then
+          env_var "DEPLOYMENT_FORCE_JDBC_DRIVER_ADDON" "false"
+          env_var "DEPLOYMENT_MYSQL_DRIVER_VERSION" "5.1.25" #Default version used to download additional mysql driver
+          env_var "DEPLOYMENT_POSTGRESQL_ADDON_VERSION" "1.0.0" # Default version of the jdbc postgresql driver addon to use
+          env_var "DEPLOYMENT_POSTGRESQL_DRIVER_VERSION" "9.4.1208" #Default version used to download additional postgresql driver
+          env_var "DEPLOYMENT_ORACLE_DRIVER_VERSION" "12.1.0.1"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_GROUPID" "com.microsoft"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_ARTIFACTID" "sqljdbc"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_REPO" "private"
+          env_var "DEPLOYMENT_SQLSERVER_DRIVER_VERSION" "4.0.2206.100"
+        else 
+          echo_error "Invalid plf version \"${PRODUCT_BRANCH}\""
+          exit 1
+        fi
       fi
 
     ;;

--- a/_functions_jbosseap.sh
+++ b/_functions_jbosseap.sh
@@ -46,43 +46,7 @@ do_configure_jbosseap_datasources() {
     MYSQL | DOCKER_MYSQL | DOCKER_MARIADB)
       find_instance_file DB_SERVER_PATCH "${ETC_DIR}/${DEPLOYMENT_APPSRV_TYPE}${DEPLOYMENT_APPSRV_VERSION:0:1}" "standalone-exo-mysql.xml.patch" "${DB_SERVER_PATCH_PRODUCT_NAME}"
 
-      if [ ! -f ${DEPLOYMENT_DIR}/standalone/deployments/mysql-connector*.jar ]; then
-        MYSQL_JAR_URL="http://repository.exoplatform.org/public/mysql/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/mysql-connector-java-${DEPLOYMENT_MYSQL_DRIVER_VERSION}.jar"
-        if [ ! -e ${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/`basename ${MYSQL_JAR_URL}` ]; then
-          if ${ADT_OFFLINE}; then
-            echo_error "ADT is offine and the MySQL JDBC Driver isn't available locally"
-            exit 1
-          else
-            mkdir -p ${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/
-            echo_info "Downloading MySQL JDBC driver from ${MYSQL_JAR_URL} ..."
-            set +e
-            curl --fail --show-error --location-trusted ${MYSQL_JAR_URL} > ${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/`basename ${MYSQL_JAR_URL}`
-            if [ "$?" -ne "0" ]; then
-              echo_error "Cannot download ${MYSQL_JAR_URL}"
-              rm -f "${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/"`basename ${MYSQL_JAR_URL}` # Remove potential corrupted file
-              exit 1
-            fi
-            set -e
-            echo_info "Done."
-          fi
-        fi
-        echo_info "Validating MySQL JDBC Driver integrity ..."
-        set +e
-        jar -tf "${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/"`basename ${MYSQL_JAR_URL}` > /dev/null
-        if [ "$?" -ne "0" ]; then
-          echo_error "Sorry, "`basename ${MYSQL_JAR_URL}`" integrity failed. Local copy is deleted."
-          rm -f "${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/"`basename ${MYSQL_JAR_URL}`
-          exit 1
-        fi
-        set -e
-        echo_info "MySQL JDBC Driver integrity validated."
-        echo_info "Installing MySQL JDBC Driver ..."
-        cp -f "${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}/"`basename ${MYSQL_JAR_URL}` ${DEPLOYMENT_DIR}/standalone/deployments/
-
-        env_var "DB_DRIVER" "$(basename ${MYSQL_JAR_URL})"
-
-        echo_info "Done."
-      fi
+      do_install_mysql_driver ${DEPLOYMENT_DIR}/standalone/deployments
     ;;
     DOCKER_POSTGRES)
       find_instance_file DB_SERVER_PATCH "${ETC_DIR}/${DEPLOYMENT_APPSRV_TYPE}${DEPLOYMENT_APPSRV_VERSION:0:1}" "standalone-exo-postgres.xml.patch" "${DB_SERVER_PATCH_PRODUCT_NAME}"

--- a/_functions_plf.sh
+++ b/_functions_plf.sh
@@ -25,6 +25,12 @@ source "${SCRIPT_DIR}/_functions_download.sh"
 # TDB : Use functions that aren't using global vars
 # #############################################################################
 
+do_download_mysql_driver() {
+  env_var "MYSQL_DL_DIR" "${DL_DIR}/mysql-connector-java/${DEPLOYMENT_MYSQL_DRIVER_VERSION}"
+  mkdir -p ${MYSQL_DL_DIR}
+  do_download_maven_artifact "${REPOSITORY_SERVER_BASE_URL}/content/groups/public" "" "" "mysql" "mysql-connector-java" "${DEPLOYMENT_MYSQL_DRIVER_VERSION}" "jar" "" "${MYSQL_DL_DIR}" "mysql-connector-java" ""
+}
+
 do_download_postgresql_driver() {
   env_var "PSQL_DL_DIR" "${DL_DIR}/postgresql-jdbc-driver/${DEPLOYMENT_POSTGRESQL_DRIVER_VERSION}"
   mkdir -p ${PSQL_DL_DIR}
@@ -40,12 +46,27 @@ do_download_oracle_driver() {
 do_download_sqlserver_driver() {
   env_var "SQLSERVER_DL_DIR" "${DL_DIR}/sqlserver-jdbc-driver/${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}"
   mkdir -p ${SQLSERVER_DL_DIR}
-  do_download_maven_artifact "${REPOSITORY_SERVER_BASE_URL}/content/groups/private" "${REPOSITORY_USERNAME}" "${REPOSITORY_PASSWORD}" "com.microsoft" "sqljdbc" "${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}" "jar" "" "${SQLSERVER_DL_DIR}" "sqljdbc" ""
+  do_download_maven_artifact "${REPOSITORY_SERVER_BASE_URL}/content/groups/${DEPLOYMENT_SQLSERVER_DRIVER_REPO}" "${REPOSITORY_USERNAME}" "${REPOSITORY_PASSWORD}" "${DEPLOYMENT_SQLSERVER_DRIVER_GROUPID}" "${DEPLOYMENT_SQLSERVER_DRIVER_ARTIFACTID}" "${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}" "jar" "" "${SQLSERVER_DL_DIR}" "sqljdbc" ""
+}
+
+do_install_mysql_driver() {
+  local _installDir=$1
+  
+  echo_info "Using standard mysql jdbc driver version ${DEPLOYMENT_MYSQL_DRIVER_VERSION}"
+
+  do_download_mysql_driver
+    
+  cp ${MYSQL_DL_DIR}/mysql-connector-java-${DEPLOYMENT_MYSQL_DRIVER_VERSION}.jar $1
+
+  # TODO Find a way to determine the driver name from the addon version
+  env_var "DB_DRIVER" "mysql-connector-java-${DEPLOYMENT_MYSQL_DRIVER_VERSION}.jar"
 }
 
 do_install_postgresql_driver() {
   local _installDir=$1
   
+  echo_info "Using standard postgresql jdbc driver version ${DEPLOYMENT_POSTGRESQL_DRIVER_VERSION}"
+
   do_download_postgresql_driver
 
   cp ${PSQL_DL_DIR}/postgresql-${DEPLOYMENT_POSTGRESQL_DRIVER_VERSION}.jar $1
@@ -57,6 +78,8 @@ do_install_postgresql_driver() {
 do_install_oracle_driver() {
   local _installDir=$1
   
+  echo_info "Using standard oracle jdbc driver version ${DEPLOYMENT_ORACLE_DRIVER_VERSION}"
+
   do_download_oracle_driver
 
   cp ${ORACLE_DL_DIR}/ojdbc-${DEPLOYMENT_ORACLE_DRIVER_VERSION}.jar $1
@@ -69,6 +92,8 @@ do_install_oracle_driver() {
 do_install_sqlserver_driver() {
   local _installDir=$1
   
+  echo_info "Using standard sqlserver jdbc driver version ${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}"
+
   do_download_sqlserver_driver
 
   cp ${SQLSERVER_DL_DIR}/sqljdbc-${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}.jar $1
@@ -76,7 +101,6 @@ do_install_sqlserver_driver() {
   # TODO Find a way to determine the driver name from the addon version
   env_var "DB_DRIVER" "sqljdbc-${DEPLOYMENT_SQLSERVER_DRIVER_VERSION}.jar"
 }
-
 
 #
 # Function that installs the addons manager


### PR DESCRIPTION
* Use the addon when it's possible
* Use the last addon version for 5.0 instances
* Use the right jdbc driver version for jboss  when the addon is not used
