### PR TITLE
ACC-92 : add missing default add-ons for eXo 5.3 and 6.0 in ADT UI

### DIFF
--- a/var/www/lib/functions.php
+++ b/var/www/lib/functions.php
@@ -353,6 +353,10 @@ function getLocalAcceptanceInstances()
       switch ($descriptor_array['PRODUCT_NAME']) {
         case 'plfcom':
           switch ($descriptor_array['PRODUCT_BRANCH']) {
+            case '6.0.x':
+            case '5.3.x':
+              $descriptor_array['PRODUCT_ADDONS_DISTRIB']="exo-es-embedded / exo-kudos / exo-perk-store / exo-wallet / exo-gamification";
+              break;
             case '5.2.x':
             case '5.1.x':
             case '5.0.x':
@@ -373,6 +377,10 @@ function getLocalAcceptanceInstances()
         case 'plfent':
         case 'plfenteap':
           switch ($descriptor_array['PRODUCT_BRANCH']) {
+            case '6.0.x':
+            case '5.3.x':
+              $descriptor_array['PRODUCT_ADDONS_DISTRIB']="exo-es-embedded / exo-remote-edit / exo-tasks / exo-web-pack / exo-web-conferencing / exo-enterprise-skin / exo-push-notifications / exo-kudos / exo-perk-store / exo-wallet / exo-gamification";
+              break;
             case '5.2.x':
               $descriptor_array['PRODUCT_ADDONS_DISTRIB']="exo-es-embedded / exo-remote-edit / exo-tasks / exo-web-pack / exo-web-conferencing / exo-enterprise-skin / exo-push-notifications";
               break;


### PR DESCRIPTION
To fix the missing info on the UI for eXo 5.3 and 6.0 streams

![adt-ACC-92](https://user-images.githubusercontent.com/120171/67669567-72419780-f972-11e9-9419-fd9506cafedc.png)
