### PR TITLE
ACC-140 : improve OnlyOffice version management

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -266,8 +266,7 @@ initialize_product_settings() {
       configurable_env_var "DEPLOYMENT_ES_IMAGE" "exoplatform/elasticsearch"
 
       env_var "DEPLOYMENT_ONLYOFFICE_DOCUMENTSERVER_ENABLED" false
-      configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE" "onlyoffice/documentserver"
-      configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE_VERSION" "5.2.2.2"
+      configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE" "onlyoffice/documentserver-ie"
       configurable_env_var "DEPLOYMENT_ONLYOFFICE_SECRET" ""
 
       configurable_env_var "DEPLOYMENT_LDAP_ENABLED" false
@@ -752,6 +751,8 @@ initialize_product_settings() {
               env_var "DEPLOYMENT_ORACLE_DEFAULT_VERSION" "12cR2_plf" # Default version of the oracle server to use
               env_var "DEPLOYMENT_SQLSERVER_DEFAULT_VERSION" "2017-CU2" # Default version of the sqlserver server to use
 
+              configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE_VERSION" "5.3.0.243" # Default version for Only Office docker image to use
+
           elif [[ "${PRODUCT_VERSION}" =~ ^(5.3) ]]; then
               env_var "DEPLOYMENT_ES_IMAGE_VERSION" "1.2.2"
               env_var "DEPLOYMENT_CHAT_MONGODB_VERSION" "4.0"
@@ -762,6 +763,8 @@ initialize_product_settings() {
               env_var "DEPLOYMENT_MYSQL_DEFAULT_VERSION" "5.7" # Default version of the mysql server to use
               env_var "DEPLOYMENT_POSTGRESQL_DEFAULT_VERSION" "10" # Default version of the postgresql server to use
           
+              configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE_VERSION" "5.4.0.21" # Default version for Only Office docker image to use
+
           elif [[ "${PRODUCT_VERSION}" =~ ^(6.0) ]]; then
               env_var "DEPLOYMENT_ES_IMAGE_VERSION" "1.2.2"
               env_var "DEPLOYMENT_CHAT_MONGODB_VERSION" "4.0"
@@ -772,6 +775,7 @@ initialize_product_settings() {
               env_var "DEPLOYMENT_MYSQL_DEFAULT_VERSION" "5.7" # Default version of the mysql server to use
               env_var "DEPLOYMENT_POSTGRESQL_DEFAULT_VERSION" "10" # Default version of the postgresql server to use
 
+              configurable_env_var "DEPLOYMENT_ONLYOFFICE_IMAGE_VERSION" "5.4.0.21" # Default version for Only Office docker image to use
           else 
               echo_error "Product version \"${PRODUCT_VERSION}\" not yet managed"
               exit 1


### PR DESCRIPTION
-  the image is now onlyoffice/documentserver-ie
- eXo 5.2 use version 5.3.0.243
- eXo 5.3 use version 5.3.0.243
- eXo 6.0 use version 5.4.0.21