### PR TITLE
Change referenced Distribution From eXo CE to Meeds

### DIFF
--- a/var/www/lib/functions.php
+++ b/var/www/lib/functions.php
@@ -143,7 +143,7 @@ function getRepositories()
         "perk-store" => "Perk store",
         "push-notifications" => "Push notifications",
         "addons-manager" => "Addons Manager",
-        "platform-public-distributions" => "PLF Public Dist",
+        "meeds" => "Meeds Distribution",
         "platform-private-distributions" => "PLF Private Dist",
         "wiki" => "Wiki",
         "jcr" => "JCR",


### PR DESCRIPTION
Actually, the platform-public-distribution is not used anymore, but Meeds-io:meeds.
This PR fixes the used repository name.