### PR TITLE
Optimize PLF Shutdown while NO_DATA is choosed

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -1666,7 +1666,7 @@ do_stop() {
             export CATALINA_HOME=${DEPLOYMENT_DIR}
             export CATALINA_PID=${DEPLOYMENT_PID_FILE}
           fi
-          if [ "${ACTION}" = "undeploy" ] && [ -f "${DEPLOYMENT_PID_FILE}" ]; then 
+          if ([ "${ACTION}" = "undeploy" ] || [ "${DEPLOYMENT_MODE}" = "NO_DATA" ]) && [ -f "${DEPLOYMENT_PID_FILE}" ]; then 
             pid="$(cat ${DEPLOYMENT_PID_FILE})"
             kill -9 ${pid}
           else  


### PR DESCRIPTION
Since the "NO_DATA" option is selected, there is no need to wait for the server to power off gracefully.
This will reduce the redeployment time.