### PR TITLE
Prevent data loss when instance deployment fails

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -1594,7 +1594,8 @@ do_deploy() {
   fi
   if [ "${DEPLOYMENT_MODE}" == "KEEP_DATA" ]; then
     echo_info "Archiving existing data ${INSTANCE_DESCRIPTION} ..."
-    _tmpdir=`mktemp -d -t archive-data.XXXXXXXXXX` || exit 1
+    _tmpdir="/tmp/archive-data.${INSTANCE_KEY}.${ACCEPTANCE_HOST}"
+    mkdir -p "${_tmpdir}"
     echo_info "Using temporary directory ${_tmpdir}"
     if [ ! -e "${ADT_CONF_DIR}/${INSTANCE_KEY}.${ACCEPTANCE_HOST}" ]; then
       echo_warn "This instance wasn't deployed before. Nothing to keep."


### PR DESCRIPTION
The problem came from the naming of the temporary folder which changes each run which leads to the data loss (even storage leak) for each failure. These changes make sure the ADT job handles a persistent folder name for each instance.