### PR TITLE
Add Healthchecks to docker containers (ES, Frontail, Iframely, Mongo, Keycloak, MySQL, Postgres, Mailhog, OO)

### DIFF
--- a/_functions_database.sh
+++ b/_functions_database.sh
@@ -276,6 +276,10 @@ do_start_database() {
         -e MYSQL_DATABASE=${DEPLOYMENT_DATABASE_NAME} \
         -e MYSQL_USER=${DEPLOYMENT_DATABASE_USER} \
         -e MYSQL_PASSWORD=${DEPLOYMENT_DATABASE_USER} \
+        --health-cmd="mysqladmin -h 'localhost' -u ${DEPLOYMENT_DATABASE_USER} -p${DEPLOYMENT_DATABASE_USER} ping --silent" \
+        --health-interval=30s \
+        --health-timeout=30s \
+        --health-retries=3 \
         --name ${DEPLOYMENT_CONTAINER_NAME} ${DEPLOYMENT_DATABASE_IMAGE}:${DEPLOYMENT_DATABASE_VERSION}
     ;;
     DOCKER_POSTGRES)

--- a/_functions_database.sh
+++ b/_functions_database.sh
@@ -292,6 +292,10 @@ do_start_database() {
         -e POSTGRES_DB=${DEPLOYMENT_DATABASE_NAME} \
         -e POSTGRES_USER=${DEPLOYMENT_DATABASE_USER} \
         -e POSTGRES_PASSWORD=${DEPLOYMENT_DATABASE_USER} \
+        --health-cmd="sh -c 'pg_isready -U ${DEPLOYMENT_DATABASE_USER} -d ${DEPLOYMENT_DATABASE_NAME}'" \
+        --health-interval=30s \
+        --health-timeout=30s \
+        --health-retries=3 \
         --name ${DEPLOYMENT_CONTAINER_NAME} ${DEPLOYMENT_DATABASE_IMAGE}:${DEPLOYMENT_DATABASE_VERSION}
     ;;
     DOCKER_ORACLE)

--- a/_functions_es.sh
+++ b/_functions_es.sh
@@ -99,6 +99,11 @@ do_start_es() {
         -e "xpack.security.enabled=false" \
         -e "network.host=_site_" \
         -e "reindex.remote.whitelist=${DEPLOYMENT_ES_OLD_INTERNAL_ADDR}:9200" \
+        -h 'search' \
+        --health-cmd='curl --silent --fail search:9200/_cluster/health || exit 1' \
+        --health-interval=30s \
+        --health-timeout=30s \
+        --health-retries=3 \
         --name ${DEPLOYMENT_ES_CONTAINER_NAME} ${DEPLOYMENT_ES_IMAGE}:${DEPLOYMENT_ES_IMAGE_VERSION}
     else 
       ${DOCKER_CMD} run \
@@ -111,6 +116,11 @@ do_start_es() {
         -e "cluster.initial_master_nodes=${INSTANCE_KEY}" \
         -e "xpack.security.enabled=false" \
         -e "network.host=_site_" \
+        -h 'search' \
+        --health-cmd='curl --silent --fail search:9200/_cluster/health || exit 1' \
+        --health-interval=30s \
+        --health-timeout=30s \
+        --health-retries=3 \
         --name ${DEPLOYMENT_ES_CONTAINER_NAME} ${DEPLOYMENT_ES_IMAGE}:${DEPLOYMENT_ES_IMAGE_VERSION}
     fi  
   else 
@@ -122,6 +132,11 @@ do_start_es() {
       -e "node.name=${INSTANCE_KEY}" \
       -e "cluster.name=${INSTANCE_KEY}" \
       -e "xpack.monitoring.enabled=false" \
+      -h 'search' \
+      --health-cmd='curl --silent --fail search:9200/_cluster/health || exit 1' \
+      --health-interval=30s \
+      --health-timeout=30s \
+      --health-retries=3 \
       --name ${DEPLOYMENT_ES_CONTAINER_NAME} ${DEPLOYMENT_ES_IMAGE}:${DEPLOYMENT_ES_IMAGE_VERSION}
   fi
 
@@ -211,6 +226,11 @@ do_upgrade(){
         -e "node.name=${INSTANCE_KEY}" \
         -e "cluster.name=${INSTANCE_KEY}" \
         -e "xpack.monitoring.enabled=false" \
+        -h 'search-old' \
+        --health-cmd='curl --silent --fail search-old:9200/_cluster/health || exit 1' \
+        --health-interval=30s \
+        --health-timeout=30s \
+        --health-retries=3 \
         --name ${DEPLOYMENT_ES_CONTAINER_NAME}_old ${DEPLOYMENT_ES_IMAGE}:1.2.2 # FIXME VARIABLIZE IT 
 
       check_es_availability ${DEPLOYMENT_ES_OLD_HTTP_PORT}

--- a/_functions_frontail.sh
+++ b/_functions_frontail.sh
@@ -61,6 +61,11 @@ do_start_frontail() {
     -d \
     -p "${DEPLOYMENT_FRONTAIL_HTTP_PORT}:9001" \
     -v "$(dirname ${DEPLOYMENT_LOG_PATH}):/logs" \
+    -h 'frontail' \
+    --health-cmd="timeout 2 /bin/bash -c '</dev/tcp/frontail/9001' || exit 1" \
+    --health-interval=30s \
+    --health-timeout=30s \
+    --health-retries=3 \
     --name ${DEPLOYMENT_FRONTAIL_CONTAINER_NAME} ${DEPLOYMENT_FRONTAIL_IMAGE}:${DEPLOYMENT_FRONTAIL_IMAGE_VERSION} --disable-usage-stats --url-path /livelogs /logs/${DEPLOYMENT_SERVER_LOG_FILE}
   echo_info "${DEPLOYMENT_FRONTAIL_CONTAINER_NAME} container started"  
   check_frontail_availability

--- a/_functions_iframely.sh
+++ b/_functions_iframely.sh
@@ -67,6 +67,11 @@ do_start_iframely() {
   ${DOCKER_CMD} run \
     -d \
     -p "${DEPLOYMENT_IFRAMELY_PORT}:8061" \
+    -h 'iframely' \
+    --health-cmd='wget -qO- http://iframely:8061 &> /dev/null || exit 1' \
+    --health-interval=30s \
+    --health-timeout=30s \
+    --health-retries=3 \
     --name ${DEPLOYMENT_IFRAMELY_CONTAINER_NAME} ${DEPLOYMENT_IFRAMELY_IMAGE}:${DEPLOYMENT_IFRAMELY_IMAGE_VERSION}
   echo_info "${DEPLOYMENT_IFRAMELY_CONTAINER_NAME} container started"
 

--- a/_functions_keycloak.sh
+++ b/_functions_keycloak.sh
@@ -84,6 +84,10 @@ do_start_keycloak() {
   -e KC_HTTP_RELATIVE_PATH=/auth \
   -p "${DEPLOYMENT_KEYCLOAK_HTTP_PORT}:8080" \
   -v ${DEPLOYMENT_KEYCLOAK_CONTAINER_NAME}:/opt/keycloak/data \
+  --health-cmd="timeout 2 /bin/bash -c '</dev/tcp/localhost/8080' || exit 1" \
+  --health-interval=30s \
+  --health-timeout=30s \
+  --health-retries=3 \
   --name ${DEPLOYMENT_KEYCLOAK_CONTAINER_NAME} ${DEPLOYMENT_KEYCLOAK_IMAGE}:${DEPLOYMENT_KEYCLOAK_IMAGE_VERSION} start-dev ${_startArgs}
   echo_info "${DEPLOYMENT_KEYCLOAK_CONTAINER_NAME} container started"  
   check_keycloak_availability

--- a/_functions_mailhog.sh
+++ b/_functions_mailhog.sh
@@ -63,6 +63,10 @@ do_start_mailhog() {
     -d \
     -p "${DEPLOYMENT_MAILHOG_SMTP_PORT}:1025" \
     -p "${DEPLOYMENT_MAILHOG_HTTP_PORT}:8025" \
+    --health-cmd="printf 'EHLO healthcheck\n' | nc 127.0.0.1 1025 | grep -qE '^220.*ESMTP MailHog' || exit 1" \
+    --health-interval=30s \
+    --health-timeout=30s \
+    --health-retries=3 \
     --name ${DEPLOYMENT_MAILHOG_CONTAINER_NAME} ${DEPLOYMENT_MAILHOG_IMAGE}:${DEPLOYMENT_MAILHOG_IMAGE_VERSION}
   echo_info "${DEPLOYMENT_MAILHOG_CONTAINER_NAME} container started"  
   check_mailhog_availability

--- a/_functions_onlyoffice.sh
+++ b/_functions_onlyoffice.sh
@@ -115,6 +115,11 @@ do_start_onlyoffice() {
       -v ${DEPLOYMENT_ONLYOFFICE_CONTAINER_NAME}_data:/var/www/onlyoffice/Data  \
       -v ${DEPLOYMENT_ONLYOFFICE_CONTAINER_NAME}_lib:/var/lib/onlyoffice  \
       -v ${DEPLOYMENT_ONLYOFFICE_CONTAINER_NAME}_db:/var/lib/postgresql  \
+      -h "onlyoffice" \
+      --health-cmd="curl --silent --fail onlyoffice/healthcheck || exit 1" \
+      --health-interval=30s \
+      --health-timeout=30s \
+      --health-retries=3 \
       --name ${DEPLOYMENT_ONLYOFFICE_CONTAINER_NAME} ${DEPLOYMENT_ONLYOFFICE_IMAGE}:${DEPLOYMENT_ONLYOFFICE_IMAGE_VERSION}
   fi 
   echo_info "${DEPLOYMENT_ONLYOFFICE_CONTAINER_NAME} container started"


### PR DESCRIPTION
- Add Healthcheck to ES
- Add Healthcheck to Frontail
- Add Healthcheck to Iframely
- Add Healthcheck to mongo
- Add Healthcheck to keycloak
- Add Healthcheck to MySQL
- Add Healthcheck to Postgres
- Add Healthcheck to mailhog
- Add Healthcheck to OnlyOffice

Jitsi and other services health checks will be added soon.