### PR TITLE
Upgrade Keycloak to 26.1 and Implement API-Based Permanent Admin User Creation

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -347,7 +347,7 @@ initialize_product_settings() {
 
       configurable_env_var "DEPLOYMENT_KEYCLOAK_ENABLED" false
       configurable_env_var "DEPLOYMENT_KEYCLOAK_IMAGE" "quay.io/keycloak/keycloak"
-      configurable_env_var "DEPLOYMENT_KEYCLOAK_IMAGE_VERSION" "25.0"
+      configurable_env_var "DEPLOYMENT_KEYCLOAK_IMAGE_VERSION" "26.1"
       configurable_env_var "DEPLOYMENT_KEYCLOAK_MODE" "SAML"
 
       configurable_env_var "DEPLOYMENT_CLOUDBEAVER_ENABLED" false


### PR DESCRIPTION
Keycloak now secures the bootstrap admin user (the user created by the docker run command), displaying a warning upon connection and treating it as a temporary user. As a result, the root username should no longer be created via the Docker CLI, as it was previously. This change updates the Keycloak version to 26.1 (the latest as of today) and introduces a new approach where the root user is created using its API services during the initial data setup.