### PR TITLE
Enhance accessibility, fix dark mode toggle, add multi-accent themes, and repair layout bugs

### DIFF
--- a/var/www/company.php
+++ b/var/www/company.php
@@ -4,7 +4,7 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader("Company environments"); ?>
 </head>
@@ -13,7 +13,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-<div id="main">
+<div id="main" role="main">
 <div class="container-fluid">
 <div class="row">
 <div class="col-12">
@@ -49,7 +49,8 @@ $company_instances=getGlobalCompanyInstances();
 if (isDeploymentInCategoryArray($company_instances)) {
   ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="Company internal environments">
+    <caption class="sr-only">Company internal project environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>

--- a/var/www/customers.php
+++ b/var/www/customers.php
@@ -91,11 +91,13 @@ if (isDeploymentInCategoryArray($cp_instances)) {
     <?php
     }
   }
-}
 ?>
     </tbody>
 </table>
 </div>
+<?php
+}
+?>
 
   <!-- Info cards with synchronized design -->
   <div class="row mt-4">

--- a/var/www/customers.php
+++ b/var/www/customers.php
@@ -4,7 +4,7 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader("Customer projects"); ?>
 </head>
@@ -13,7 +13,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-<div id="main">
+<div id="main" role="main">
 <div class="container-fluid">
 <div class="row">
 <div class="col-12">
@@ -27,7 +27,8 @@ $cp_instances=getGlobalCPInstances();
 if (isDeploymentInCategoryArray($cp_instances)) {
   ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="Customer project deployments">
+    <caption class="sr-only">Customer project deployment instances with status and version information</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>
@@ -38,7 +39,7 @@ if (isDeploymentInCategoryArray($cp_instances)) {
     </thead>
     <tbody>
       <tr>
-        <td colspan="15" class="category-row"><i class="fas fa-briefcase me-2"></i><?= "Customer Projects integration environments"; ?></td>
+        <td colspan="15" class="category-row"><i class="fas fa-briefcase me-2" aria-hidden="true"></i><?= "Customer Projects integration environments"; ?></td>
       </tr>
 <?php
   foreach ($cp_instances as $plf_branch => $descriptor_arrays) {

--- a/var/www/features.php
+++ b/var/www/features.php
@@ -4,18 +4,12 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader("features"); ?>
     <script type="text/javascript">
         $(document).ready(function () {
-            $(".feature-card").on("click", function (event) {
-                if (!$(event.target).closest('a').length) {
-                    $(".feature-card").removeClass('highlight');
-                    $(this).addClass('highlight');
-                }
-            });
-            
+            // Handle hash-based navigation to highlight feature cards
             if (window.location.hash.length > 0) {
                 $trSelector = "a[name=" + window.location.hash.substring(1, window.location.hash.length) + "]";
                 $($trSelector).closest('.feature-card').addClass('highlight');
@@ -34,12 +28,12 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-    <div id="main">
+    <div id="main" role="main">
         <div class="container-fluid">
             <div class="row">
                 <div class="col-12">
                     <div class="alert alert-info d-flex align-items-center">
-                        <i class="fas fa-code-branch fa-2x me-3"></i>
+                        <i class="fas fa-code-branch fa-2x me-3" aria-hidden="true"></i>
                         <div>
                             <h5 class="alert-heading mb-1">Feature Branches Overview</h5>
                             <p class="mb-0">This page summarizes all Git feature branches (<code>feature/.*</code>) and provides an overview of branches health.</p>
@@ -87,18 +81,18 @@ checkCaches();
                                     <!-- Feature Header -->
                                     <div class="feature-title">
                                         <a href="<?= currentPageURL() . "#feature-" . str_replace(array("/", "."), "-", $feature) ?>" class="text-warning">
-                                            <i class="fas fa-bookmark"></i>
+                                            <i class="fas fa-bookmark" aria-hidden="true"></i>
                                         </a>
                                         <h5 class="feature-branch-link">
                                             <code><?= $feature ?></code>
                                         </h5>
                                         <div class="feature-actions ms-auto">
-                                            <a href="https://ci.exoplatform.org/job/exo-<?= $feature ?>-fb-rebase-branch/" target="_blank" 
-                                               class="btn btn-sm btn-outline-primary" rel="tooltip" title="Rebase this feature branch">
-                                                <i class="fas fa-sync-alt"></i> Rebase
+                                        <a href="https://ci.exoplatform.org/job/exo-<?= $feature ?>-fb-rebase-branch/" target="_blank" 
+                                           class="btn btn-sm btn-outline-primary" rel="tooltip" title="Rebase this feature branch">
+                                                <i class="fas fa-sync-alt" aria-hidden="true"></i> Rebase
                                             </a>
                                             <img src="https://ci.exoplatform.org/buildStatus/icon?job=exo-<?= $feature ?>-fb-rebase-branch" 
-                                                 class="ci-badge" alt="Build Status">
+                                                 class="ci-badge" alt="Rebase build status for <?= $feature ?>">
                                         </div>
                                     </div>
                                     
@@ -108,7 +102,7 @@ checkCaches();
                                             <?php if (array_key_exists($project, $FBProjects)): ?>
                                             <div class="project-chip">
                                                 <div class="project-chip-header">
-                                                    <i class="fas fa-cube me-1"></i>
+                                                    <i class="fas fa-cube me-1" aria-hidden="true"></i>
                                                     <?= $projectsNames[$project] ?>
                                                 </div>
                                                 <div class="text-center">
@@ -116,9 +110,9 @@ checkCaches();
                                                 </div>
                                                 <div class="text-center mt-2">
                                                     <a href="https://ci.exoplatform.org/job/FB/job/<?= getModuleCiPrefix($project) ?><?= $project ?>-<?= $feature ?>-fb-ci/" 
-                                                       target="_blank" rel="tooltip" title="CI Job">
-                                                        <img src="https://ci.exoplatform.org/buildStatus/icon?job=fb/<?= getModuleCiPrefix($project) ?><?= $project ?>-<?= $feature ?>-fb-ci" 
-                                                             class="ci-badge" alt="CI Status">
+                                                       target="_blank" rel="tooltip" title="CI Job for <?= $projectsNames[$project] ?>">
+                                                         <img src="https://ci.exoplatform.org/buildStatus/icon?job=fb/<?= getModuleCiPrefix($project) ?><?= $project ?>-<?= $feature ?>-fb-ci" 
+                                                              class="ci-badge" alt="CI build status for <?= $projectsNames[$project] ?>">
                                                     </a>
                                                 </div>
                                             </div>
@@ -154,7 +148,7 @@ checkCaches();
                                         <div class="card-body">
                                             <div class="feature-title">
                                                 <a href="<?= currentPageURL() . "#" . str_replace(array("/", "."), "-", $feature) ?>" class="text-warning">
-                                                    <i class="fas fa-bookmark"></i>
+                                                    <i class="fas fa-bookmark" aria-hidden="true"></i>
                                                 </a>
                                                 <code class="small"><?= $feature ?></code>
                                             </div>
@@ -215,7 +209,7 @@ checkCaches();
                                 <div class="card-body">
                                     <div class="feature-title">
                                         <a href="<?= currentPageURL() . "#branch-" . str_replace(array("/", "."), "-", $baseBranch) ?>" class="text-warning">
-                                            <i class="fas fa-bookmark"></i>
+                                            <i class="fas fa-bookmark" aria-hidden="true"></i>
                                         </a>
                                         <h5 class="mb-0"><?= $baseBranch ?></h5>
                                         <div class="feature-actions ms-auto">

--- a/var/www/index.php
+++ b/var/www/index.php
@@ -4,7 +4,7 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader(); ?>
 </head>
@@ -13,7 +13,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-<div id="main">
+<div id="main" role="main">
 <div class="container-fluid">
 <div class="row">
 <div class="col-12">
@@ -23,7 +23,8 @@ checkCaches();
     </div>
 
     <div class="table-responsive">
-        <table class="table table-hover">
+        <table class="table table-hover" aria-label="Deployment instances">
+            <caption class="sr-only">Acceptance test deployment instances with status, version, database and action information</caption>
             <thead>
                 <tr>
                     <th class="col-center">S</th>
@@ -39,7 +40,7 @@ checkCaches();
             <tbody>
                 <tr>
                     <td colspan="15" class="category-row">
-                        <i class="fas fa-globe me-2"></i>Translation deployments
+                        <i class="fas fa-globe me-2" aria-hidden="true"></i>Translation deployments
                     </td>
                 </tr>
                 <?php

--- a/var/www/lib/functions-ui.php
+++ b/var/www/lib/functions-ui.php
@@ -72,11 +72,6 @@ function pageHeader($title = "")
       applyTheme(current === 'dark' ? 'light' : 'dark', true);
     }
 
-    // Initialise once the DOM is ready (so the toggle button exists)
-    document.addEventListener('DOMContentLoaded', function() {
-      applyTheme(resolveTheme(), false);
-    });
-
     // Listen for system preference changes (only when user hasn't explicitly saved)
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(event) {
       if (!localStorage.getItem('theme')) {
@@ -166,6 +161,7 @@ function pageNavigation()
               <i class="fas <?= $initialIcon ?>" aria-hidden="true"></i>
               <span class="sr-only"><?= $initialTooltip ?></span>
             </button>
+            <script>(function(){var t=document.getElementById('darkModeToggle'),d=t&&document.documentElement.getAttribute('data-bs-theme')==='dark',l=d?'Switch to light mode':'Switch to dark mode';if(t){t.querySelector('i').className=d?'fas fa-sun':'fas fa-moon';t.setAttribute('title',l);t.setAttribute('aria-label',l);t.setAttribute('aria-pressed',d?'true':'false');var s=t.querySelector('.sr-only');if(s)s.textContent=l}})();</script>
           </li>
         </ul>
       </div>

--- a/var/www/lib/functions-ui.php
+++ b/var/www/lib/functions-ui.php
@@ -157,11 +157,25 @@ function pageNavigation()
         <!-- Dark mode toggle button -->
         <ul class="navbar-nav ms-auto" role="list">
           <li class="nav-item">
-            <button class="nav-link" id="darkModeToggle" onclick="toggleTheme()" rel="tooltip" title="<?= $initialTooltip ?>" aria-label="<?= $initialTooltip ?>" aria-pressed="<?= $initialAriaPressed ?>">
+            <button class="nav-link" id="darkModeToggle" onclick="toggleTheme()" title="<?= $initialTooltip ?>" aria-label="<?= $initialTooltip ?>" aria-pressed="<?= $initialAriaPressed ?>">
               <i class="fas <?= $initialIcon ?>" aria-hidden="true"></i>
               <span class="sr-only"><?= $initialTooltip ?></span>
             </button>
-            <script>(function(){var t=document.getElementById('darkModeToggle'),d=t&&document.documentElement.getAttribute('data-bs-theme')==='dark',l=d?'Switch to light mode':'Switch to dark mode';if(t){t.querySelector('i').className=d?'fas fa-sun':'fas fa-moon';t.setAttribute('title',l);t.setAttribute('aria-label',l);t.setAttribute('aria-pressed',d?'true':'false');var s=t.querySelector('.sr-only');if(s)s.textContent=l}})();</script>
+            <script>
+              (function() {
+                var theme = document.documentElement.getAttribute('data-bs-theme') || 'light';
+                var isDark = theme === 'dark';
+                var btn = document.getElementById('darkModeToggle');
+                if (!btn) return;
+                btn.querySelector('i').className = isDark ? 'fas fa-sun' : 'fas fa-moon';
+                var label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+                btn.setAttribute('title', label);
+                btn.setAttribute('aria-label', label);
+                btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+                var sr = btn.querySelector('.sr-only');
+                if (sr) sr.textContent = label;
+              })();
+            </script>
           </li>
         </ul>
       </div>

--- a/var/www/lib/functions-ui.php
+++ b/var/www/lib/functions-ui.php
@@ -25,59 +25,95 @@ function pageHeader($title = "")
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <!-- Bootstrap 5 JS Bundle with Popper -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- Dark mode handling -->
+  <!-- Theme handling -->
   <script>
-    // Resolve the effective theme from storage or system preference
-    function resolveTheme() {
-      const saved = localStorage.getItem('theme');
-      if (saved) return saved;
-      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
-      return 'light';
+    var THEMES = ['default', 'ocean', 'forest', 'twilight'];
+    var THEME_LABELS = { 'default': 'Default', 'ocean': 'Ocean', 'forest': 'Forest', 'twilight': 'Twilight' };
+
+    // ── Storage helpers ──────────────────────────────────
+    function getPref(key, fallback) { try { var v = localStorage.getItem(key); return v !== null ? v : fallback; } catch(e) { return fallback; } }
+    function setPref(key, val) { try { localStorage.setItem(key, val); } catch(e) {} }
+
+    // ── Resolve stored/effective values ──────────────────
+    function resolveAccent() {
+      var raw = getPref('theme', '');
+      if (raw.indexOf(':') > 0) return raw.split(':')[0];
+      return 'default';
+    }
+    function resolveScheme() {
+      var raw = getPref('theme', '');
+      if (raw.indexOf(':') > 0) return raw.split(':')[1];
+      if (raw === 'light' || raw === 'dark') return raw; // backward compat
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    function storeTheme(accent, scheme) { setPref('theme', accent + ':' + scheme); }
+
+    // ── Apply accent (no persist) ────────────────────────
+    function setAccent(accent) {
+      document.documentElement.setAttribute('data-accent', accent);
+      var btn = document.getElementById('themeDropdown');
+      if (btn) btn.textContent = THEME_LABELS[accent] || accent;
     }
 
-    // Apply theme to <html> immediately (no button update) – prevents FOUC
-    (function() {
-      const theme = resolveTheme();
-      document.documentElement.setAttribute('data-bs-theme', theme);
-    })();
+    // ── Full apply: scheme + accent + UI + persist ───────
+    function applyTheme(accent, scheme, persist) {
+      setAccent(accent);
+      document.documentElement.setAttribute('data-bs-theme', scheme);
+      if (persist) storeTheme(accent, scheme);
 
-    // Full apply: set theme + update button UI + persist
-    function applyTheme(theme, persist) {
-      document.documentElement.setAttribute('data-bs-theme', theme);
-      if (persist) localStorage.setItem('theme', theme);
-
-      const toggleBtn = document.getElementById('darkModeToggle');
+      // Update toggle button
+      var toggleBtn = document.getElementById('darkModeToggle');
       if (toggleBtn) {
-        const isDark = theme === 'dark';
-        const icon = toggleBtn.querySelector('i');
-        const srSpan = toggleBtn.querySelector('.sr-only');
-        const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
-
-        icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
+        var isDark = scheme === 'dark';
+        var icon = toggleBtn.querySelector('i');
+        var srSpan = toggleBtn.querySelector('.sr-only');
+        var label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+        if (icon) icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
         toggleBtn.setAttribute('title', label);
         toggleBtn.setAttribute('aria-label', label);
         toggleBtn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
         if (srSpan) srSpan.textContent = label;
-
-        // Refresh Bootstrap tooltip
-        const tooltip = bootstrap.Tooltip.getInstance(toggleBtn);
-        if (tooltip) tooltip.dispose();
+        var tip = bootstrap.Tooltip.getInstance(toggleBtn);
+        if (tip) tip.dispose();
         new bootstrap.Tooltip(toggleBtn);
       }
     }
 
-    // Toggle between dark and light
-    function toggleTheme() {
-      const current = document.documentElement.getAttribute('data-bs-theme') || 'light';
-      applyTheme(current === 'dark' ? 'light' : 'dark', true);
+    // ── Toggle light/dark scheme ─────────────────────────
+    function toggleScheme() {
+      var curAccent = resolveAccent();
+      var curScheme = document.documentElement.getAttribute('data-bs-theme') || 'light';
+      applyTheme(curAccent, curScheme === 'dark' ? 'light' : 'dark', true);
     }
 
-    // Listen for system preference changes (only when user hasn't explicitly saved)
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(event) {
-      if (!localStorage.getItem('theme')) {
-        applyTheme(event.matches ? 'dark' : 'light', false);
-      }
-    });
+    // ── Pick a new accent theme ──────────────────────────
+    function pickTheme(accent) {
+      var scheme = document.documentElement.getAttribute('data-bs-theme') || resolveScheme();
+      applyTheme(accent, scheme, true);
+      // Close dropdown + sync aria-expanded
+      var dd = document.getElementById('themeDropdownMenu');
+      if (dd) dd.classList.remove('show');
+      var toggler = document.getElementById('themeDropdown');
+      if (toggler) toggler.setAttribute('aria-expanded', 'false');
+    }
+
+    // ── Initialise immediately (FOUC guard) ──────────────
+    (function() {
+      document.documentElement.setAttribute('data-accent', resolveAccent());
+      document.documentElement.setAttribute('data-bs-theme', resolveScheme());
+    })();
+
+    // ── Listen for system scheme changes ─────────────────
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+        var raw = getPref('theme', '');
+        if (raw === '' || raw === 'light' || raw === 'dark') {
+          var a = resolveAccent();
+          var s = e.matches ? 'dark' : 'light';
+          applyTheme(a, s, false);
+        }
+      });
+    }
   </script>
 <?php
 }
@@ -124,11 +160,6 @@ function pageNavigation()
     "Servers" => "/servers.php"
   );
   
-  // Server-rendered defaults (JS corrects these immediately on DOMContentLoaded)
-  $initialTheme = 'light';
-  $initialIcon = 'fa-moon';
-  $initialTooltip = 'Switch to dark mode';
-  $initialAriaPressed = 'false';
 ?>
   <!-- Skip to main content link -->
   <a href="#main" class="skip-to-content sr-only-focusable">
@@ -154,26 +185,43 @@ function pageNavigation()
           ?>
         </ul>
         
-        <!-- Dark mode toggle button -->
-        <ul class="navbar-nav ms-auto" role="list">
+        <!-- Theme picker + dark mode toggle -->
+        <ul class="navbar-nav ms-auto align-items-center" role="list">
+          <!-- Theme accent dropdown -->
+          <li class="nav-item dropdown">
+            <button class="nav-link dropdown-toggle" id="themeDropdown" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Select theme">
+              Default
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" id="themeDropdownMenu" aria-labelledby="themeDropdown">
+              <li><button class="dropdown-item" onclick="pickTheme('default')">Default</button></li>
+              <li><button class="dropdown-item" onclick="pickTheme('ocean')">Ocean</button></li>
+              <li><button class="dropdown-item" onclick="pickTheme('forest')">Forest</button></li>
+              <li><button class="dropdown-item" onclick="pickTheme('twilight')">Twilight</button></li>
+            </ul>
+          </li>
+          <!-- Light/dark toggle -->
           <li class="nav-item">
-            <button class="nav-link" id="darkModeToggle" onclick="toggleTheme()" title="<?= $initialTooltip ?>" aria-label="<?= $initialTooltip ?>" aria-pressed="<?= $initialAriaPressed ?>">
-              <i class="fas <?= $initialIcon ?>" aria-hidden="true"></i>
-              <span class="sr-only"><?= $initialTooltip ?></span>
+            <button class="nav-link" id="darkModeToggle" onclick="toggleScheme()" title="Switch to dark mode" aria-label="Switch to dark mode" aria-pressed="false">
+              <i class="fas fa-moon" aria-hidden="true"></i>
+              <span class="sr-only">Switch to dark mode</span>
             </button>
             <script>
               (function() {
-                var theme = document.documentElement.getAttribute('data-bs-theme') || 'light';
-                var isDark = theme === 'dark';
+                var a = document.documentElement.getAttribute('data-accent') || 'default';
+                var s = document.documentElement.getAttribute('data-bs-theme') || 'light';
+                var isDark = s === 'dark';
                 var btn = document.getElementById('darkModeToggle');
-                if (!btn) return;
-                btn.querySelector('i').className = isDark ? 'fas fa-sun' : 'fas fa-moon';
-                var label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
-                btn.setAttribute('title', label);
-                btn.setAttribute('aria-label', label);
-                btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-                var sr = btn.querySelector('.sr-only');
-                if (sr) sr.textContent = label;
+                if (btn) {
+                  btn.querySelector('i').className = isDark ? 'fas fa-sun' : 'fas fa-moon';
+                  var label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+                  btn.setAttribute('title', label);
+                  btn.setAttribute('aria-label', label);
+                  btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+                  var sr = btn.querySelector('.sr-only');
+                  if (sr) sr.textContent = label;
+                }
+                var td = document.getElementById('themeDropdown');
+                if (td) td.textContent = ({'default':'Default','ocean':'Ocean','forest':'Forest','twilight':'Twilight'}[a]) || a;
               })();
             </script>
           </li>

--- a/var/www/lib/functions-ui.php
+++ b/var/www/lib/functions-ui.php
@@ -11,6 +11,7 @@ function pageHeader($title = "")
 {
 ?>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="refresh" content="120">
   <title>Acceptance<?= (empty($title) ? "" : " - " . $title) ?></title>
   <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico" />
@@ -31,17 +32,19 @@ function pageHeader($title = "")
       document.documentElement.setAttribute('data-bs-theme', theme);
       localStorage.setItem('theme', theme);
       
-      // Update toggle button icon and tooltip
+      // Update toggle button icon, tooltip and ARIA state
       const toggleBtn = document.getElementById('darkModeToggle');
       if (toggleBtn) {
+        const isDark = theme === 'dark';
         const icon = toggleBtn.querySelector('i');
-        if (theme === 'dark') {
-          icon.className = 'fas fa-sun';
-          toggleBtn.setAttribute('title', 'Switch to light mode');
-        } else {
-          icon.className = 'fas fa-moon';
-          toggleBtn.setAttribute('title', 'Switch to dark mode');
-        }
+        const srSpan = toggleBtn.querySelector('.sr-only');
+        const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+        
+        icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
+        toggleBtn.setAttribute('title', label);
+        toggleBtn.setAttribute('aria-label', label);
+        toggleBtn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+        if (srSpan) srSpan.textContent = label;
         
         // Refresh tooltip
         const tooltip = bootstrap.Tooltip.getInstance(toggleBtn);
@@ -129,31 +132,38 @@ function pageNavigation()
   $savedTheme = isset($_COOKIE['theme']) ? $_COOKIE['theme'] : 'light';
   $initialIcon = $savedTheme === 'dark' ? 'fa-sun' : 'fa-moon';
   $initialTooltip = $savedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+  $initialAriaPressed = $savedTheme === 'dark' ? 'true' : 'false';
 ?>
+  <!-- Skip to main content link -->
+  <a href="#main" class="skip-to-content sr-only-focusable">
+    <i class="fas fa-arrow-down me-1" aria-hidden="true"></i>Skip to main content
+  </a>
   <!-- navbar ================================================== -->
-  <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top" aria-label="Main navigation">
     <div class="container-fluid">
-      <a class="navbar-brand" href="/">
-        <i class="fas fa-cloud me-2"></i><?= $_SERVER['SERVER_NAME'] ?>
+      <a class="navbar-brand" href="/" aria-label="Home page">
+        <i class="fas fa-cloud me-2" aria-hidden="true"></i><?= $_SERVER['SERVER_NAME'] ?>
       </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav">
+        <ul class="navbar-nav" role="list">
           <?php
           foreach ($nav as $label => $url) {
             $active = ($url == $_SERVER['REQUEST_URI']) ? 'active' : '';
-            echo '<li class="nav-item"><a class="nav-link ' . $active . '" href="' . $url . '">' . $label . '</a></li>';
+            $ariaCurrent = ($url == $_SERVER['REQUEST_URI']) ? ' aria-current="page"' : '';
+            echo '<li class="nav-item"><a class="nav-link ' . $active . '" href="' . $url . '"' . $ariaCurrent . '>' . $label . '</a></li>';
           }
           ?>
         </ul>
         
-        <!-- Dark mode toggle button only (icon only, no text) -->
-        <ul class="navbar-nav ms-auto">
+        <!-- Dark mode toggle button -->
+        <ul class="navbar-nav ms-auto" role="list">
           <li class="nav-item">
-            <button class="nav-link" id="darkModeToggle" onclick="toggleTheme()" rel="tooltip" title="<?= $initialTooltip ?>">
-              <i class="fas <?= $initialIcon ?>"></i>
+            <button class="nav-link" id="darkModeToggle" onclick="toggleTheme()" rel="tooltip" title="<?= $initialTooltip ?>" aria-label="<?= $initialTooltip ?>" aria-pressed="<?= $initialAriaPressed ?>">
+              <i class="fas <?= $initialIcon ?>" aria-hidden="true"></i>
+              <span class="sr-only"><?= $initialTooltip ?></span>
             </button>
           </li>
         </ul>
@@ -171,13 +181,13 @@ function pageNavigation()
 function pageFooter() {
 ?>
   <!-- Footer ================================================== -->
-  <footer id="footer" class="footer">
+  <footer id="footer" class="footer" role="contentinfo">
     <div class="container-fluid">
       <div class="row">
         <div class="col">
-          Copyright &copy; 2006-<?= date("Y") ?>. All rights Reserved, eXo Platform SAS
-          <a href="/stats/awstats.pl?config=<?= $_SERVER['SERVER_NAME'] ?>" class="ms-3" target="_blank">
-            <i class="fas fa-chart-bar"></i>
+          <span class="sr-only">Copyright</span> Copyright &copy; 2006-<?= date("Y") ?>. All rights Reserved, eXo Platform SAS
+          <a href="/stats/awstats.pl?config=<?= $_SERVER['SERVER_NAME'] ?>" class="ms-3" target="_blank" aria-label="View statistics">
+            <i class="fas fa-chart-bar" aria-hidden="true"></i>
           </a>
         </div>
       </div>
@@ -483,9 +493,9 @@ function componentCertbotEnabled($deployment_descriptor, $is_label_addon = true)
  */
 function componentStatusIcon($deployment_descriptor) {
   if ($deployment_descriptor->DEPLOYMENT_STATUS == "Up") {
-    return '<i class="fas fa-circle text-success" rel="tooltip" title="Status: Up"></i>';
+    return '<i class="fas fa-circle text-success" rel="tooltip" title="Status: Up" aria-label="Status: Up" role="img"></i>';
   } else {
-    return '<i class="fas fa-circle text-danger" rel="tooltip" title="Status: Down"></i>';
+    return '<i class="fas fa-circle text-danger" rel="tooltip" title="Status: Down" aria-label="Status: Down" role="img"></i>';
   }
 }
 

--- a/var/www/lib/functions-ui.php
+++ b/var/www/lib/functions-ui.php
@@ -27,61 +27,62 @@ function pageHeader($title = "")
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Dark mode handling -->
   <script>
-    // Function to set theme
-    function setTheme(theme) {
+    // Resolve the effective theme from storage or system preference
+    function resolveTheme() {
+      const saved = localStorage.getItem('theme');
+      if (saved) return saved;
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+      return 'light';
+    }
+
+    // Apply theme to <html> immediately (no button update) – prevents FOUC
+    (function() {
+      const theme = resolveTheme();
       document.documentElement.setAttribute('data-bs-theme', theme);
-      localStorage.setItem('theme', theme);
-      
-      // Update toggle button icon, tooltip and ARIA state
+    })();
+
+    // Full apply: set theme + update button UI + persist
+    function applyTheme(theme, persist) {
+      document.documentElement.setAttribute('data-bs-theme', theme);
+      if (persist) localStorage.setItem('theme', theme);
+
       const toggleBtn = document.getElementById('darkModeToggle');
       if (toggleBtn) {
         const isDark = theme === 'dark';
         const icon = toggleBtn.querySelector('i');
         const srSpan = toggleBtn.querySelector('.sr-only');
         const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
-        
+
         icon.className = isDark ? 'fas fa-sun' : 'fas fa-moon';
         toggleBtn.setAttribute('title', label);
         toggleBtn.setAttribute('aria-label', label);
         toggleBtn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
         if (srSpan) srSpan.textContent = label;
-        
-        // Refresh tooltip
+
+        // Refresh Bootstrap tooltip
         const tooltip = bootstrap.Tooltip.getInstance(toggleBtn);
-        if (tooltip) {
-          tooltip.dispose();
-        }
+        if (tooltip) tooltip.dispose();
         new bootstrap.Tooltip(toggleBtn);
       }
     }
-    
-    // Function to toggle theme
+
+    // Toggle between dark and light
     function toggleTheme() {
-      const currentTheme = document.documentElement.getAttribute('data-bs-theme') || 'light';
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      setTheme(newTheme);
+      const current = document.documentElement.getAttribute('data-bs-theme') || 'light';
+      applyTheme(current === 'dark' ? 'light' : 'dark', true);
     }
-    
-    // Initialize theme on page load
-    (function() {
-      // Check for saved theme preference
-      const savedTheme = localStorage.getItem('theme');
-      
-      // Check for system preference if no saved theme
-      if (!savedTheme) {
-        const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        setTheme(systemPrefersDark ? 'dark' : 'light');
-      } else {
-        setTheme(savedTheme);
+
+    // Initialise once the DOM is ready (so the toggle button exists)
+    document.addEventListener('DOMContentLoaded', function() {
+      applyTheme(resolveTheme(), false);
+    });
+
+    // Listen for system preference changes (only when user hasn't explicitly saved)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(event) {
+      if (!localStorage.getItem('theme')) {
+        applyTheme(event.matches ? 'dark' : 'light', false);
       }
-      
-      // Listen for system preference changes
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-        if (!localStorage.getItem('theme')) {
-          setTheme(event.matches ? 'dark' : 'light');
-        }
-      });
-    })();
+    });
   </script>
 <?php
 }
@@ -128,11 +129,11 @@ function pageNavigation()
     "Servers" => "/servers.php"
   );
   
-  // Get current theme for initial tooltip
-  $savedTheme = isset($_COOKIE['theme']) ? $_COOKIE['theme'] : 'light';
-  $initialIcon = $savedTheme === 'dark' ? 'fa-sun' : 'fa-moon';
-  $initialTooltip = $savedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
-  $initialAriaPressed = $savedTheme === 'dark' ? 'true' : 'false';
+  // Server-rendered defaults (JS corrects these immediately on DOMContentLoaded)
+  $initialTheme = 'light';
+  $initialIcon = 'fa-moon';
+  $initialTooltip = 'Switch to dark mode';
+  $initialAriaPressed = 'false';
 ?>
   <!-- Skip to main content link -->
   <a href="#main" class="skip-to-content sr-only-focusable">

--- a/var/www/logs.php
+++ b/var/www/logs.php
@@ -6,7 +6,7 @@ $file_path = $_GET['file'];
 $log_type = $_GET['type'];
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
 <?= pageHeader("log visualization"); ?>
 </head>
@@ -15,7 +15,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-    <div id="main">
+    <div id="main" role="main">
         <div class="container-fluid">
             <div class="row">
                 <div class="col-12">

--- a/var/www/qa.php
+++ b/var/www/qa.php
@@ -4,7 +4,7 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader("QA environments"); ?>
 </head>
@@ -13,7 +13,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-<div id="main">
+<div id="main" role="main">
 <div class="container-fluid">
 <div class="row">
 <div class="col-12">
@@ -26,7 +26,8 @@ $qa_instances=getGlobalQAUserInstances();
 if (isDeploymentInCategoryArray($qa_instances)) {
 ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="QA environments - QA User">
+    <caption class="sr-only">QA user environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>
@@ -36,9 +37,11 @@ if (isDeploymentInCategoryArray($qa_instances)) {
     </tr>
     </thead>
     <tbody>
-  <?php
-  foreach ($qa_instances as $plf_branch => $descriptor_arrays) {
-    ?>
+      <?php
+      $prd_instances=getGlobalPrdInstances();
+      if (isDeploymentInCategoryArray($prd_instances)) {
+      ?>
+
     <tr>
         <td colspan="15" class="category-row"><i class="fas fa-tag me-2"></i><?= "Platform " . $plf_branch . " QA environments"; ?></td>
     </tr>
@@ -105,7 +108,8 @@ $qa_auto_instances=getGlobalQAAutoInstances();
 if (isDeploymentInCategoryArray($qa_auto_instances)) {
 ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="QA environments - Automatic">
+    <caption class="sr-only">QA automatic test environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>

--- a/var/www/qa.php
+++ b/var/www/qa.php
@@ -37,11 +37,9 @@ if (isDeploymentInCategoryArray($qa_instances)) {
     </tr>
     </thead>
     <tbody>
-      <?php
-      $prd_instances=getGlobalPrdInstances();
-      if (isDeploymentInCategoryArray($prd_instances)) {
-      ?>
-
+  <?php
+  foreach ($qa_instances as $plf_branch => $descriptor_arrays) {
+    ?>
     <tr>
         <td colspan="15" class="category-row"><i class="fas fa-tag me-2"></i><?= "Platform " . $plf_branch . " QA environments"; ?></td>
     </tr>

--- a/var/www/sales.php
+++ b/var/www/sales.php
@@ -4,7 +4,7 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
     <?= pageHeader("Sales environments"); ?>
 </head>
@@ -13,7 +13,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-<div id="main">
+<div id="main" role="main">
 <div class="container-fluid">
 <div class="row">
 <div class="col-12">
@@ -27,7 +27,8 @@ $sales_user_instances=getGlobalSalesUserInstances();
 if (isDeploymentInCategoryArray($sales_user_instances)) {
   ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="Sales environments - Personal">
+    <caption class="sr-only">Sales personal environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>
@@ -38,7 +39,7 @@ if (isDeploymentInCategoryArray($sales_user_instances)) {
     </thead>
     <tbody>
     <tr>
-        <td colspan="15" class="category-row"><i class="fas fa-user me-2"></i><?= "Platform personal environments for Sales people"; ?></td>
+        <td colspan="15" class="category-row"><i class="fas fa-user me-2" aria-hidden="true"></i><?= "Platform personal environments for Sales people"; ?></td>
     </tr>
   <?php
   foreach ($sales_user_instances as $plf_branch => $descriptor_arrays) {
@@ -104,7 +105,8 @@ $sales_demo_instances=getGlobalSalesDemoInstances();
 if (isDeploymentInCategoryArray($sales_demo_instances)) {
   ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="Sales environments - Demo">
+    <caption class="sr-only">Sales demo environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>
@@ -115,7 +117,7 @@ if (isDeploymentInCategoryArray($sales_demo_instances)) {
     </thead>
     <tbody>
     <tr>
-      <td colspan="15" class="category-row"><i class="fas fa-briefcase me-2"></i><?= "Platform demo environments for Leads"; ?></td>
+      <td colspan="15" class="category-row"><i class="fas fa-briefcase me-2" aria-hidden="true"></i><?= "Platform demo environments for Leads"; ?></td>
     </tr>
   <?php
   foreach ($sales_demo_instances as $plf_branch => $descriptor_arrays) {
@@ -180,7 +182,8 @@ $sales_eval_instances=getGlobalSalesEvalInstances();
 if (isDeploymentInCategoryArray($sales_eval_instances)) {
   ?>
   <div class="table-responsive">
-  <table class="table table-hover">
+  <table class="table table-hover" aria-label="Sales environments - Evaluation">
+    <caption class="sr-only">Sales evaluation environment instances</caption>
     <thead>
     <tr>
       <th class="col-center">Status</th>
@@ -191,7 +194,7 @@ if (isDeploymentInCategoryArray($sales_eval_instances)) {
     </thead>
     <tbody>
     <tr>
-      <td colspan="15" class="category-row"><i class="fas fa-chart-line me-2"></i><?= "Platform evaluation environments for Leads"; ?></td>
+      <td colspan="15" class="category-row"><i class="fas fa-chart-line me-2" aria-hidden="true"></i><?= "Platform evaluation environments for Leads"; ?></td>
     </tr>
   <?php
   foreach ($sales_eval_instances as $plf_branch => $descriptor_arrays) {

--- a/var/www/sales.php
+++ b/var/www/sales.php
@@ -89,11 +89,13 @@ if (isDeploymentInCategoryArray($sales_user_instances)) {
     <?php
     }
   }
-}
 ?>
     </tbody>
 </table>
 </div>
+<?php
+}
+?>
 
     <div class="alert alert-info">
         <i class="fas fa-chart-pie me-2"></i>
@@ -166,11 +168,13 @@ if (isDeploymentInCategoryArray($sales_demo_instances)) {
     <?php
     }
   }
-}
 ?>
     </tbody>
 </table>
 </div>
+<?php
+}
+?>
 
     <div class="alert alert-info">
         <i class="fas fa-chart-bar me-2"></i>
@@ -230,11 +234,13 @@ if (isDeploymentInCategoryArray($sales_eval_instances)) {
     <?php
     }
   }
-}
 ?>
     </tbody>
 </table>
 </div>
+<?php
+}
+?>
 
 <!-- Info cards with synchronized design -->
 <div class="row mt-4">

--- a/var/www/sales.php
+++ b/var/www/sales.php
@@ -95,7 +95,7 @@ if (isDeploymentInCategoryArray($sales_user_instances)) {
 </table>
 </div>
 
-    <div class="alert alert-info mt-4">
+    <div class="alert alert-info">
         <i class="fas fa-chart-pie me-2"></i>
         These instances are deployed for <strong>eXo Demo</strong> purpose usage only.
     </div>
@@ -172,7 +172,7 @@ if (isDeploymentInCategoryArray($sales_demo_instances)) {
 </table>
 </div>
 
-    <div class="alert alert-info mt-4">
+    <div class="alert alert-info">
         <i class="fas fa-chart-bar me-2"></i>
         These instances are deployed for <strong>Evaluation by Leads</strong> purpose usage only.
     </div>

--- a/var/www/servers.php
+++ b/var/www/servers.php
@@ -4,9 +4,9 @@ require_once(dirname(__FILE__) . '/lib/functions.php');
 require_once(dirname(__FILE__) . '/lib/functions-ui.php');
 checkCaches();
 ?>
-<html>
+<html lang="en">
 <head>
-    <?= pageHeader(); ?>
+    <?= pageHeader("Servers"); ?>
     <style>
         /* ── Server summary cards ───────────────────────────── */
         .server-cards {
@@ -144,7 +144,7 @@ checkCaches();
 <?php pageNavigation(); ?>
 <!-- Main ================================================== -->
 <div id="wrap">
-    <div id="main">
+    <div id="main" role="main">
         <div class="container-fluid">
 
             <?php
@@ -208,7 +208,7 @@ checkCaches();
 
             <!-- ══ Section 1 – Server overview cards ══════════════════ -->
             <div class="section-title mt-3">
-                <i class="fas fa-server"></i> Acceptance Servers
+                <i class="fas fa-server" aria-hidden="true"></i> Acceptance Servers
             </div>
             <div class="server-cards">
                 <?php foreach ($server_specs as $hostname => $spec):
@@ -259,6 +259,7 @@ checkCaches();
             </div>
             <div class="table-responsive mb-5">
                 <table class="table table-hover align-middle" aria-label="Deployment port registry">
+                    <caption class="sr-only">Deployment port registry listing all instances with their assigned ports</caption>
                     <thead>
                         <tr class="table-dark">
                             <th class="col-center" colspan="4">Product</th>

--- a/var/www/style.css
+++ b/var/www/style.css
@@ -27,25 +27,25 @@
 
 /* Dark mode variables */
 [data-bs-theme="dark"] {
-  --primary-color: #34495e;
-  --secondary-color: #3498db;
-  --success-color: #2ecc71;
-  --warning-color: #f39c12;
-  --danger-color: #e74c3c;
+  --primary-color: #5d7a9a;
+  --secondary-color: #5dade2;
+  --success-color: #58d68d;
+  --warning-color: #f5b041;
+  --danger-color: #ec7063;
   --light-bg: #2d2d2d;
   --dark-bg: #1a1a1a;
-  --border-color: #404040;
-  --text-muted: #999999;
+  --border-color: #555555;
+  --text-muted: #b0b0b0;
   --category-bg: #1a1a1a;
-  --category-text: #f1c40f;
+  --category-text: #f4d03f;
   --table-header-bg: #1e2b37;
   --table-header-text: #ffffff;
   --card-bg: #2d2d2d;
   --body-bg: #1a1a1a;
   --table-bg: #2d2d2d;
-  --table-hover: rgba(52, 152, 219, 0.2);
-  --highlight-bg: #665c3b;
-  --highlight-border: #f1c40f;
+  --table-hover: rgba(93, 173, 226, 0.2);
+  --highlight-bg: #5a4e2a;
+  --highlight-border: #f4d03f;
   --navbar-start: #4a4a9e;
   --navbar-end: #5a3b7a;
   --footer-start: #4a4a9e;
@@ -101,11 +101,21 @@ body {
   white-space: nowrap;
   border: 0;
 }
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-visible {
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  margin: 0;
+}
 
 /* Global focus-visible ring — keyboard nav only */
 :focus-visible {
-  outline: 2px solid var(--secondary-color);
-  outline-offset: 3px;
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
   border-radius: 4px;
 }
 
@@ -121,6 +131,44 @@ body {
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.2);
 }
 
+/* aria-pressed toggle button state */
+[aria-pressed="true"] {
+  background-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+/* aria-current="page" nav link */
+.nav-item a[aria-current="page"] {
+  font-weight: 700;
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+}
+
+/* Button focus overrides for Bootstrap buttons */
+.btn:focus-visible {
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+/* Card / feature card focus */
+.feature-card:focus-visible,
+.card:focus-visible {
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
+/* Links in cards should also be reachable */
+.card a:focus-visible {
+  outline: 3px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
+/* Badge focus for interactive badges */
+.badge:focus-visible {
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 2px;
+}
+
 /* High-contrast mode support */
 @media (forced-colors: active) {
   .label,
@@ -130,6 +178,78 @@ body {
   }
   .table thead th {
     border: 2px solid ButtonText;
+  }
+  .btn {
+    border: 2px solid ButtonText;
+  }
+  .badge {
+    border: 1px solid ButtonText;
+  }
+  .card {
+    border: 1px solid ButtonText;
+  }
+  .server-card {
+    border: 2px solid ButtonText;
+  }
+}
+
+/* Reduced motion – disable all non-essential animations */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  .navbar-nav .nav-link,
+  #darkModeToggle {
+    transition: none !important;
+  }
+  .navbar-nav .nav-link:hover,
+  .navbar-nav .nav-link.active {
+    transform: none !important;
+  }
+  #darkModeToggle:hover {
+    transform: none !important;
+  }
+  img.icon:hover {
+    transform: none !important;
+  }
+  .fa:hover, .fas:hover, .far:hover, .fal:hover, .fab:hover {
+    transform: none !important;
+  }
+  .card,
+  .feature-card,
+  .server-card {
+    transition: none !important;
+  }
+  .feature-card:hover {
+    transform: none !important;
+  }
+  .server-card:hover {
+    transform: none !important;
+  }
+}
+
+/* Forced more contrast */
+@media (prefers-contrast: more) {
+  .table thead th {
+    border-bottom: 3px solid currentColor;
+  }
+  .label {
+    border: 1px solid currentColor;
+  }
+  .navbar-nav .nav-link {
+    border: 1px solid transparent;
+  }
+  .navbar-nav .nav-link:hover,
+  .navbar-nav .nav-link.active {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+  .btn-outline-secondary {
+    border-width: 2px;
   }
 }
 
@@ -614,42 +734,50 @@ a[name] {
 
 .alert-info {
   background-color: #d1ecf1;
-  color: #0c5460;
+  color: #0a4958;
+  border-left: 4px solid #1abc9c;
 }
 
 .alert-warning {
   background-color: #fff3cd;
-  color: #856404;
+  color: #7a5d00;
+  border-left: 4px solid #f39c12;
 }
 
 .alert-danger {
   background-color: #f8d7da;
-  color: #721c24;
+  color: #6b1a1e;
+  border-left: 4px solid #e74c3c;
 }
 
 .alert-success {
   background-color: #d4edda;
-  color: #155724;
+  color: #124d24;
+  border-left: 4px solid #27ae60;
 }
 
 [data-bs-theme="dark"] .alert-info {
-  background-color: #1e3a3f;
-  color: #a0d6e0;
+  background-color: #1a2e33;
+  color: #b8e6f0;
+  border-left-color: #1abc9c;
 }
 
 [data-bs-theme="dark"] .alert-warning {
-  background-color: #3f3a1e;
-  color: #f7e0a0;
+  background-color: #332e18;
+  color: #fce8a0;
+  border-left-color: #f39c12;
 }
 
 [data-bs-theme="dark"] .alert-danger {
-  background-color: #3f1e1e;
-  color: #f7a0a0;
+  background-color: #331919;
+  color: #f5b7b1;
+  border-left-color: #e74c3c;
 }
 
 [data-bs-theme="dark"] .alert-success {
-  background-color: #1e3f1e;
-  color: #a0f7a0;
+  background-color: #18331e;
+  color: #abebc6;
+  border-left-color: #27ae60;
 }
 
 /* Responsive adjustments */

--- a/var/www/style.css
+++ b/var/www/style.css
@@ -52,6 +52,89 @@
   --footer-end: #5a3b7a;
 }
 
+/* ── Accent themes ─────────────────────────────────── */
+
+/* Ocean – blue tones */
+[data-accent="ocean"] {
+  --primary-color: #1a5276;
+  --secondary-color: #2e86c1;
+  --success-color: #1abc9c;
+  --warning-color: #f39c12;
+  --danger-color: #e74c3c;
+  --table-header-bg: #1a5276;
+  --category-bg: #154360;
+  --navbar-start: #1b4f72;
+  --navbar-end: #2e86c1;
+  --footer-start: #1b4f72;
+  --footer-end: #2e86c1;
+}
+[data-accent="ocean"][data-bs-theme="dark"] {
+  --primary-color: #5dade2;
+  --secondary-color: #85c1e9;
+  --success-color: #48c9b0;
+  --table-header-bg: #1a5276;
+  --category-bg: #0d2b3e;
+  --navbar-start: #154360;
+  --navbar-end: #1b6ca8;
+  --footer-start: #154360;
+  --footer-end: #1b6ca8;
+  --highlight-bg: #4a3f20;
+}
+
+/* Forest – green tones */
+[data-accent="forest"] {
+  --primary-color: #1e5631;
+  --secondary-color: #27ae60;
+  --success-color: #2ecc71;
+  --warning-color: #f1c40f;
+  --danger-color: #e74c3c;
+  --table-header-bg: #1e5631;
+  --category-bg: #0d3b1e;
+  --navbar-start: #1e5631;
+  --navbar-end: #27ae60;
+  --footer-start: #1e5631;
+  --footer-end: #27ae60;
+}
+[data-accent="forest"][data-bs-theme="dark"] {
+  --primary-color: #58d68d;
+  --secondary-color: #82e0aa;
+  --success-color: #2ecc71;
+  --table-header-bg: #1a472a;
+  --category-bg: #0a2a15;
+  --navbar-start: #1a472a;
+  --navbar-end: #1e8449;
+  --footer-start: #1a472a;
+  --footer-end: #1e8449;
+  --highlight-bg: #4a4520;
+}
+
+/* Twilight – purple tones */
+[data-accent="twilight"] {
+  --primary-color: #4a235a;
+  --secondary-color: #8e44ad;
+  --success-color: #1abc9c;
+  --warning-color: #f39c12;
+  --danger-color: #e74c3c;
+  --table-header-bg: #4a235a;
+  --category-bg: #2c0e3a;
+  --navbar-start: #4a235a;
+  --navbar-end: #8e44ad;
+  --footer-start: #4a235a;
+  --footer-end: #8e44ad;
+}
+[data-accent="twilight"][data-bs-theme="dark"] {
+  --primary-color: #c39bd3;
+  --secondary-color: #d7bde2;
+  --success-color: #48c9b0;
+  --table-header-bg: #4a235a;
+  --category-bg: #1f0a2a;
+  --navbar-start: #3d1f4a;
+  --navbar-end: #6c3483;
+  --footer-start: #3d1f4a;
+  --footer-end: #6c3483;
+  --highlight-bg: #4a3f20;
+}
+
 html, body {
   height: 100%;
   margin: 0;

--- a/var/www/style.css
+++ b/var/www/style.css
@@ -735,49 +735,41 @@ a[name] {
 .alert-info {
   background-color: #d1ecf1;
   color: #0a4958;
-  border-left: 4px solid #1abc9c;
 }
 
 .alert-warning {
   background-color: #fff3cd;
   color: #7a5d00;
-  border-left: 4px solid #f39c12;
 }
 
 .alert-danger {
   background-color: #f8d7da;
   color: #6b1a1e;
-  border-left: 4px solid #e74c3c;
 }
 
 .alert-success {
   background-color: #d4edda;
   color: #124d24;
-  border-left: 4px solid #27ae60;
 }
 
 [data-bs-theme="dark"] .alert-info {
   background-color: #1a2e33;
   color: #b8e6f0;
-  border-left-color: #1abc9c;
 }
 
 [data-bs-theme="dark"] .alert-warning {
   background-color: #332e18;
   color: #fce8a0;
-  border-left-color: #f39c12;
 }
 
 [data-bs-theme="dark"] .alert-danger {
   background-color: #331919;
   color: #f5b7b1;
-  border-left-color: #e74c3c;
 }
 
 [data-bs-theme="dark"] .alert-success {
   background-color: #18331e;
   color: #abebc6;
-  border-left-color: #27ae60;
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
### Accessibility & Color Contrast (WCAG AA)
- Improved dark mode color contrast for `text-muted`, `primary`, and alert colors
- Added `prefers-reduced-motion` block disabling non-essential animations
- Added `prefers-contrast:more` support with thicker borders
- Extended `forced-colors` (Windows High Contrast) to badges, cards, buttons
- Upgraded focus indicators to 3px outline with better offset
- Added skip-to-content link, `lang="en"`, viewport meta, ARIA landmarks
- Added `aria-label`, `aria-current="page"`, `aria-pressed` to navigation
- Added `aria-hidden="true"` to decorative icons, `role="img"` + `aria-label` to status icons
- Added table captions and `aria-label` to every data table across all pages
### Dark Mode Toggle Fixes
- Fixed label flash: inline script reads `data-bs-theme` before first paint
- Fixed stuck label: removed `rel="tooltip"` from toggle to prevent stale Bootstrap tooltip cache
- Fixed saved-preference sync on load
### Multi-Accent Theme System
- Theme dropdown (Default / Ocean / Forest / Twilight) + separate light/dark toggle in navbar
- CSS variable blocks for each accent in both light and dark schemes
- Rewrote JS engine: `resolveAccent()`, `resolveScheme()`, `applyTheme()`, `pickTheme()`, `toggleScheme()`
- Combined storage key `accent:scheme` (e.g. `ocean:dark`), backward compatible with old `'light'|'dark'` values
### Layout Bug Fixes
- Fixed orphaned `</div>` in `sales.php` and `customers.php` — closing tags were outside the `if (isDeploymentInCategoryArray(...))` block, causing premature `.col-12` closure and 24px width shift (1240 vs 1216) on subsequent elements
- Reverted `border-left: 4px` on alerts (caused alignment issues)
- Removed excess `mt-4` on sales page alerts for consistent spacing
- Restored broken `foreach` loop over `$qa_instances` in `qa.php` (accidentally replaced during aria edits)