### PR TITLE
Enable Brotli compression on Apache2 with Gzip fallback, disable Tomcat compression

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -429,7 +429,7 @@ initialize_product_settings() {
       configurable_env_var "DEPLOYMENT_CHAT_INTERMEDIATE_MONGODB_UPGRADE_VERSIONS" ""
       
       configurable_env_var "DEPLOYMENT_ES7_MIGRATION_ENABLED" false
-      configurable_env_var "DEPLOYMENT_GZIP_ENABLED" true
+      configurable_env_var "DEPLOYMENT_GZIP_ENABLED" false
       configurable_env_var "DEPLOYMENT_LOGBACK_LOGGERS" ""
       configurable_env_var "DEPLOYMENT_UPLOAD_MAX_FILE_SIZE" "200"
       configurable_env_var "DEPLOYMENT_STAGING_ENABLED" false

--- a/etc/apache2/includes/frontend.include.template
+++ b/etc/apache2/includes/frontend.include.template
@@ -14,29 +14,38 @@
     LogLevel        warn
     CustomLog       ${ADT_DATA}/var/log/apache2/${ACCEPTANCE_HOST}-access.log combined
 
-    #
-    # Compression using GZIP
-    #
-    # Insert filter
-    SetOutputFilter DEFLATE
-    SetInputFilter DEFLATE
-    DeflateFilterNote Input instream
-    DeflateFilterNote Output outstream
-    DeflateFilterNote Ratio ratio
-    # Higher Compression 9 - Medium 5
-    DeflateCompressionLevel 5
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
 
-    # Netscape 4.x has some problems...
-    BrowserMatch ^Mozilla/4 gzip-only-text/html
-    # Netscape 4.06-4.08 have some more problems
-    BrowserMatch ^Mozilla/4\.0[678] no-gzip
-    # MSIE masquerades as Netscape, but it is fine
-    BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
 
-    # Don't compress images
-    SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png)$" no-gzip dont-vary
-    # Make sure proxies don't deliver the wrong content
-    Header append Vary User-Agent env=!dont-vary
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
 
     # Turn on Expires and set default to 0
     ExpiresActive On

--- a/etc/apache2/includes/frontend.include.template
+++ b/etc/apache2/includes/frontend.include.template
@@ -18,7 +18,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-chat-standalone-oo.include.template
+++ b/etc/apache2/includes/instance-chat-standalone-oo.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-chat-standalone-oo.include.template
+++ b/etc/apache2/includes/instance-chat-standalone-oo.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-chat-standalone.include.template
+++ b/etc/apache2/includes/instance-chat-standalone.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-chat-standalone.include.template
+++ b/etc/apache2/includes/instance-chat-standalone.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-oo.include.template
+++ b/etc/apache2/includes/instance-oo.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-oo.include.template
+++ b/etc/apache2/includes/instance-oo.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-ws-meeds.include.template
+++ b/etc/apache2/includes/instance-ws-meeds.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-ws-meeds.include.template
+++ b/etc/apache2/includes/instance-ws-meeds.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-ws-oo.include.template
+++ b/etc/apache2/includes/instance-ws-oo.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-ws-oo.include.template
+++ b/etc/apache2/includes/instance-ws-oo.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance-ws.include.template
+++ b/etc/apache2/includes/instance-ws.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance-ws.include.template
+++ b/etc/apache2/includes/instance-ws.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream

--- a/etc/apache2/includes/instance.include.template
+++ b/etc/apache2/includes/instance.include.template
@@ -19,6 +19,39 @@
     # configures the footer on server-generated documents
     ServerSignature Off
 
+    <IfModule brotli_module>
+        #
+        # Compression using Brotli
+        #
+        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        BrotliCompressionQuality 5
+        BrotliFilterNote Input instream
+        BrotliFilterNote Output outstream
+        BrotliFilterNote Ratio ratio
+
+        # Don't compress images
+        SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-brotli dont-vary
+        # Make sure proxies don't deliver the wrong content
+        Header append Vary User-Agent env=!dont-vary
+    </IfModule>
+    <IfModule !brotli_module>
+        <IfModule deflate_module>
+            #
+            # Compression using Gzip (fallback)
+            #
+            SetOutputFilter DEFLATE
+            DeflateCompressionLevel 5
+            DeflateFilterNote Input instream
+            DeflateFilterNote Output outstream
+            DeflateFilterNote Ratio ratio
+
+            # Don't compress images
+            SetEnvIfNoCase Request_URI "\.(?:gif|jpe?g|png|webp)$" no-gzip dont-vary
+            # Make sure proxies don't deliver the wrong content
+            Header append Vary User-Agent env=!dont-vary
+        </IfModule>
+    </IfModule>
+
     <Directory />
         Options FollowSymLinks
         AllowOverride None

--- a/etc/apache2/includes/instance.include.template
+++ b/etc/apache2/includes/instance.include.template
@@ -23,7 +23,7 @@
         #
         # Compression using Brotli
         #
-        AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/x-font-ttf application/x-font-opentype application/vnd.ms-fontobject image/svg+xml
+        SetOutputFilter BROTLI_COMPRESS
         BrotliCompressionQuality 5
         BrotliFilterNote Input instream
         BrotliFilterNote Output outstream


### PR DESCRIPTION
- Replace mod_deflate (Gzip) with mod_brotli in frontend.include.template
- Add Brotli compression to all 7 instance include templates
- Add Gzip fallback (<IfModule deflate_module>) when Brotli is unavailable
- Wrap Brotli config in <IfModule brotli_module> for failsafe
- Disable Tomcat compression by default (DEPLOYMENT_GZIP_ENABLED=false)