### PR TITLE
Modernize Apache2 config for 2.4.58: replace legacy access controls, remove deprecated SSL directives, drop obsolete workarounds

### DIFF
--- a/_functions.sh
+++ b/_functions.sh
@@ -100,9 +100,8 @@ Environment Variables
   CROWD_ACCEPTANCE_APP_PASSWORD     : The crowd application's password used to authenticate the front-end (default: none)
   LDAP_ACCEPTANCE_BIND_DN           : The LDAP Bind DN used to authenticate the front-end (default: none)
   LDAP_ACCEPTANCE_BIND_PASSWORD     : The LDAP Bind DN's password used to authenticate the front-end (default: none)
-  APACHE_SSL_CERTIFICATE_FILE       : Apache SSLCertificateFile for HTTPS setup
+  APACHE_SSL_CERTIFICATE_FILE       : Apache SSLCertificateFile for HTTPS setup (must contain full chain)
   APACHE_SSL_CERTIFICATE_KEY_FILE   : Apache SSLCertificateKeyFile for HTTPS setup
-  APACHE_SSL_CERTIFICATE_CHAIN_FILE : Apache SSLCertificateChainFile for HTTPS setup
 
   REPOSITORY_SERVER_BASE_URL        : The Maven repository URL used to download artifacts (default: https://repository.exoplatform.org)
   REPOSITORY_USERNAME               : The username to logon on \$REPOSITORY_SERVER_BASE_URL if necessary (default: none)

--- a/_functions_certbot.sh
+++ b/_functions_certbot.sh
@@ -40,9 +40,8 @@ do_generate_certbot_certificate() {
       echo_warn "Certificate ${certFile} will expire soon. Ask ITOP for checking certbot's cron job issues"
       certbotAction="renew"
     else 
-      env_var "INSTANCE_SSL_CERTIFICATE_FILE" "${certbot_certs_folder}/${certbot_domain}/cert.pem"
+      env_var "INSTANCE_SSL_CERTIFICATE_FILE" "${certbot_certs_folder}/${certbot_domain}/fullchain.pem"
       env_var "INSTANCE_SSL_CERTIFICATE_KEY_FILE"  "${certbot_certs_folder}/${certbot_domain}/privkey.pem"
-      env_var "INSTANCE_SSL_CERTIFICATE_CHAIN_FILE" "${certbot_certs_folder}/${certbot_domain}/chain.pem"
       return 0
     fi
   fi

--- a/adt.sh
+++ b/adt.sh
@@ -159,12 +159,12 @@ case "${ACTION}" in
         echo_info "Done."
       ;;
       https)
-        if [ -f "${APACHE_SSL_CERTIFICATE_FILE}" ] && [ -f "${APACHE_SSL_CERTIFICATE_KEY_FILE}" ] && [ -f "${APACHE_SSL_CERTIFICATE_CHAIN_FILE}" ]; then
+        if [ -f "${APACHE_SSL_CERTIFICATE_FILE}" ] && [ -f "${APACHE_SSL_CERTIFICATE_KEY_FILE}" ]; then
           echo_info "Deploying Apache FrontEnd configuration for HTTP/HTTPS"
           evaluate_file_content ${ETC_DIR}/apache2/sites-available/frontend-full-https.template ${APACHE_CONF_DIR}/sites-available/acceptance.exoplatform.org
           echo_info "Done."
         else
-          echo_error "Deploying Front End with HTTPS scheme but one of \${APACHE_SSL_CERTIFICATE_FILE} (\"${APACHE_SSL_CERTIFICATE_FILE}\"),\${APACHE_SSL_CERTIFICATE_KEY_FILE} (\"${APACHE_SSL_CERTIFICATE_KEY_FILE}\"),\${APACHE_SSL_CERTIFICATE_CHAIN_FILE} (\"${APACHE_SSL_CERTIFICATE_CHAIN_FILE}\") is invalid"
+          echo_error "Deploying Front End with HTTPS scheme but one of \${APACHE_SSL_CERTIFICATE_FILE} (\"${APACHE_SSL_CERTIFICATE_FILE}\"),\${APACHE_SSL_CERTIFICATE_KEY_FILE} (\"${APACHE_SSL_CERTIFICATE_KEY_FILE}\") is invalid"
           print_usage
           exit 1
         fi

--- a/etc/apache2/includes/frontend.include.template
+++ b/etc/apache2/includes/frontend.include.template
@@ -94,40 +94,35 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes MultiViews ExecCGI
         AllowOverride None
-        Order allow,deny
-        allow from all
+        Require all granted
     </Directory>
 
     Alias /icons/ "/usr/share/apache2/icons/"
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /downloads/ "${ADT_DATA}/downloads/"
     <Directory "${ADT_DATA}/downloads/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /datasets/ "${ADT_DATA}/datasets/"
     <Directory "${ADT_DATA}/datasets/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${ADT_DATA}/var/log/apache2/"
     <Directory "${ADT_DATA}/var/log/apache2/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     #Awstats
@@ -135,16 +130,14 @@
     Alias /awstats-icon/ "/usr/share/awstats/icon/"
     Alias /awstatscss "/usr/share/doc/awstats/examples/css"
     ScriptAlias /stats/ /usr/lib/cgi-bin/
-    #Redirect by default to our public projects repositories
     RedirectMatch "^stats/?$" "/stats/awstats.pl"
-    Options -Indexes +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    <Directory /usr/lib/cgi-bin>
+        Options -Indexes +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    </Directory>
 
     # Security
     <Location />
         <IfModule authnz_crowd_module>
-            Order deny,allow
-            Allow from all
-
             AuthName "eXo Employees only"
             AuthType Basic
             AuthBasicProvider crowd
@@ -177,42 +170,27 @@
         </IfModule>
     </Location>
     <Location /rest/>
-        Order deny,allow
-        Deny from all
-        Allow from exoplatform.org
-        Satisfy any
+        Require host exoplatform.org
     </Location>
     <Location /info.php>
-        Order deny,allow
-        Deny from all
-        Allow from localhost 127.0.0.1
+        Require local
     </Location>
     <Location /google*.html>
-        Order deny,allow
-        Allow from all
-        Satisfy any
+        Require all granted
     </Location>
     <Location /robots.txt>
-        Order deny,allow
-        Allow from all
-        Satisfy any
+        Require all granted
     </Location>
 
     # PWA files — no authentication
     <Location /manifest.json>
-        Order deny,allow
-        Allow from all
-        Satisfy any
+        Require all granted
     </Location>
     <Location /sw.js>
-        Order deny,allow
-        Allow from all
-        Satisfy any
+        Require all granted
     </Location>
     <Location /images/>
-        Order deny,allow
-        Allow from all
-        Satisfy any
+        Require all granted
     </Location>
 
     AddType application/manifest+json .json

--- a/etc/apache2/includes/instance-chat-standalone-oo.include.template
+++ b/etc/apache2/includes/instance-chat-standalone-oo.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -158,8 +154,8 @@
         RewriteCond %{HTTP:Connection} upgrade [NC]
         RewriteRule ^/?(.*) "ws://localhost:${DEPLOYMENT_ONLYOFFICE_HTTP_PORT}/$1$2" [P,L]
 
-        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
-        ProxyPass /chatServer/cometd ws://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
+        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5
+        ProxyPass /chatServer/cometd ws://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer/cometd max=200 acquire=5000 retry=5
 
         <Location "/jitsiweb/xmpp-websocket">
             ProxyPass "ws://localhost:${DEPLOYMENT_JITSI_WEB_HTTP_PORT}/xmpp-websocket"
@@ -180,15 +176,13 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
     ProxyPassReverse        /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
 
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer acquire=1000 retry=30
     ProxyPassReverse        /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer
 
     ProxyPass               /elasticsearch       http://localhost:${DEPLOYMENT_ES_HTTP_PORT}
@@ -253,7 +247,5 @@
     # Add header X-Forwarded-Proto to enforce https on the underlying webserver
     RequestHeader set X-Forwarded-Proto "https"
 
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30
     ProxyPassReverse        /       http://localhost:${DEPLOYMENT_HTTP_PORT}/

--- a/etc/apache2/includes/instance-chat-standalone.include.template
+++ b/etc/apache2/includes/instance-chat-standalone.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -123,8 +119,8 @@
     ProxyPass               /images/favicon.ico  !
 
     <IfModule mod_proxy_wstunnel.c>
-        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
-        ProxyPass /chatServer/cometd ws://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
+        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5
+        ProxyPass /chatServer/cometd ws://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer/cometd max=200 acquire=5000 retry=5
         
         <Location "/cloudbeaver/api/ws">
             ProxyPass "ws://localhost:${DEPLOYMENT_CLOUDBEAVER_HTTP_PORT}/cloudbeaver/api/ws"
@@ -171,15 +167,13 @@
     </IfModule>
 
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
     ProxyPassReverse        /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
 
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer acquire=1000 retry=30
     ProxyPassReverse        /chatServer       http://localhost:${DEPLOYMENT_CHAT_SERVER_PORT}/chatServer
 
     ProxyPass               /elasticsearch       http://localhost:${DEPLOYMENT_ES_HTTP_PORT}
@@ -224,8 +218,6 @@
     ProxyPassReverse        /_matrix             http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_matrix
     ProxyPass               /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
     ProxyPassReverse        /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30
     ProxyPassReverse        /       http://localhost:${DEPLOYMENT_HTTP_PORT}/
 

--- a/etc/apache2/includes/instance-oo.include.template
+++ b/etc/apache2/includes/instance-oo.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -169,7 +165,7 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal

--- a/etc/apache2/includes/instance-ws-meeds.include.template
+++ b/etc/apache2/includes/instance-ws-meeds.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -131,7 +127,7 @@
     ProxyPass               /images/favicon.ico  !
 
     <IfModule mod_proxy_wstunnel.c>
-        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
+        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5
 
         <Location "/cloudbeaver/api/ws">
             ProxyPass "ws://localhost:${DEPLOYMENT_CLOUDBEAVER_HTTP_PORT}/cloudbeaver/api/ws"
@@ -177,7 +173,7 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
@@ -225,7 +221,5 @@
     ProxyPassReverse        /_matrix             http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_matrix
     ProxyPass               /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
     ProxyPassReverse        /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30
     ProxyPassReverse        /       http://localhost:${DEPLOYMENT_HTTP_PORT}/

--- a/etc/apache2/includes/instance-ws-oo.include.template
+++ b/etc/apache2/includes/instance-ws-oo.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -130,7 +126,7 @@
         RewriteCond %{HTTP:Connection} upgrade [NC]
         RewriteRule ^/?(.*) "ws://localhost:${DEPLOYMENT_ONLYOFFICE_HTTP_PORT}/$1$2" [P,L]
 
-        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
+        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5
 
         <Location "/cloudbeaver/api/ws">
             ProxyPass "ws://localhost:${DEPLOYMENT_CLOUDBEAVER_HTTP_PORT}/cloudbeaver/api/ws"
@@ -176,7 +172,7 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
@@ -243,7 +239,5 @@
     # Add header X-Forwarded-Proto to enforce https on the underlying webserver
     RequestHeader set X-Forwarded-Proto "https"
     
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30
     ProxyPassReverse        /       http://localhost:${DEPLOYMENT_HTTP_PORT}/

--- a/etc/apache2/includes/instance-ws.include.template
+++ b/etc/apache2/includes/instance-ws.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,23 +68,21 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 	Alias /.well-known/matrix/ "${DEPLOYMENT_DIR}/matrix/"
     <Directory "${DEPLOYMENT_DIR}/matrix/">
         Options Indexes MultiViews
         AllowOverride None
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -124,7 +120,7 @@
     ProxyPass               /images/favicon.ico  !
 
     <IfModule mod_proxy_wstunnel.c>
-        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5 disablereuse=on flushpackets=on
+        ProxyPass /cometd ws://localhost:${DEPLOYMENT_HTTP_PORT}/cometd max=200 acquire=5000 retry=5
 
         <Location "/cloudbeaver/api/ws">
             ProxyPass "ws://localhost:${DEPLOYMENT_CLOUDBEAVER_HTTP_PORT}/cloudbeaver/api/ws"
@@ -170,7 +166,7 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal
@@ -219,7 +215,5 @@
     ProxyPass               /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
     ProxyPassReverse        /_synapse            http://localhost:${DEPLOYMENT_MATRIX_HTTP_PORT}/_synapse
     # Matrix well-known for client & server
-    # ACC-90: need to force disablereuse and flushpackets to avoid WebSocket interferences
-    # Can be remove if apache version is >= 2.4.13
-    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /       http://localhost:${DEPLOYMENT_HTTP_PORT}/ acquire=1000 retry=30
     ProxyPassReverse        /       http://localhost:${DEPLOYMENT_HTTP_PORT}/

--- a/etc/apache2/includes/instance.include.template
+++ b/etc/apache2/includes/instance.include.template
@@ -61,8 +61,6 @@
     <Directory ${ADT_DATA}/var/www/>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
         Require all granted
     </Directory>
 
@@ -70,16 +68,14 @@
     <Directory "/usr/share/apache2/icons">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     Alias /logs/ "${DEPLOYMENT_DIR}/logs/"
     <Directory "${DEPLOYMENT_DIR}/logs/">
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     # Serve Certbot challenge files directly
@@ -131,7 +127,7 @@
         H2Push Off
     </IfModule>
 
-    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30 disablereuse=on flushpackets=on
+    ProxyPass               /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis acquire=1000 retry=30
     ProxyPassReverse        /cmis       http://localhost:${DEPLOYMENT_CMIS_HTTP_PORT}/cmis
 
     ProxyPass               /baikal       http://localhost:${DEPLOYMENT_CALDAV_HTTP_PORT}/baikal

--- a/etc/apache2/sites-available/frontend-full-https.template
+++ b/etc/apache2/sites-available/frontend-full-https.template
@@ -23,26 +23,12 @@
     SSLEngine             on
     SSLCertificateFile       ${APACHE_SSL_CERTIFICATE_FILE}
     SSLCertificateKeyFile    ${APACHE_SSL_CERTIFICATE_KEY_FILE}
-    SSLCertificateChainFile  ${APACHE_SSL_CERTIFICATE_CHAIN_FILE}
     SSLVerifyClient None
 
-    # configuration du SSL
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
     SSLHonorCipherOrder     on
 
     Header always set Strict-Transport-Security "max-age=63072000"
-
-    <FilesMatch "\.(cgi|shtml|phtml|php)$">
-        SSLOptions +StdEnvVars
-    </FilesMatch>
-    <Directory /usr/lib/cgi-bin>
-        SSLOptions +StdEnvVars
-    </Directory>
-    BrowserMatch "MSIE [2-6]" \
-        nokeepalive ssl-unclean-shutdown \
-        downgrade-1.0 force-response-1.0
-    # MSIE 7 and newer should be able to use keepalive
-    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
 </VirtualHost>

--- a/etc/apache2/sites-available/instance-private-with-https.template
+++ b/etc/apache2/sites-available/instance-private-with-https.template
@@ -6,25 +6,17 @@
 
     # No security for gadgets
     <ProxyMatch "^.*/(eXoGadgetServer|exo-gadget-resources|rest|.*Resources)/.*$">
-        Order allow,deny
-        Allow from all
-        Satisfy any
+        Require all granted
     </ProxyMatch>
 
     # No security for chat local access
     <ProxyMatch "^.*/chatServer/.*$">
-        Order deny,allow
-        Deny from all
-        Allow from exoplatform.org
-        Satisfy any
+        Require host exoplatform.org
     </ProxyMatch>
 
     # Everything else is secured
     <Proxy *>
         <IfModule authnz_crowd_module>
-            Order deny,allow
-            Allow from all
-
             AuthName "eXo Employees only"
             AuthType Basic
             AuthBasicProvider crowd
@@ -68,25 +60,17 @@
 
     # No security for gadgets
     <ProxyMatch "^.*/(eXoGadgetServer|exo-gadget-resources|rest|.*Resources)/.*$">
-        Order allow,deny
-        Allow from all
-        Satisfy any
+        Require all granted
     </ProxyMatch>
 
     # No security for chat local access
     <ProxyMatch "^.*/chatServer/.*$">
-        Order deny,allow
-        Deny from all
-        Allow from exoplatform.org
-        Satisfy any
+        Require host exoplatform.org
     </ProxyMatch>
 
     # Everything else is secured
     <Proxy *>
         <IfModule authnz_crowd_module>
-            Order deny,allow
-            Allow from all
-
             AuthName "eXo Employees only"
             AuthType Basic
             AuthBasicProvider crowd
@@ -125,26 +109,12 @@
     SSLEngine             on
     SSLCertificateFile       ${INSTANCE_SSL_CERTIFICATE_FILE}
     SSLCertificateKeyFile    ${INSTANCE_SSL_CERTIFICATE_KEY_FILE}
-    SSLCertificateChainFile  ${INSTANCE_SSL_CERTIFICATE_CHAIN_FILE}
     SSLVerifyClient None
 
-    # configuration du SSL
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
     SSLHonorCipherOrder     on
 
     Header always set Strict-Transport-Security "max-age=63072000"
-
-    <FilesMatch "\.(cgi|shtml|phtml|php)$">
-        SSLOptions +StdEnvVars
-    </FilesMatch>
-    <Directory /usr/lib/cgi-bin>
-        SSLOptions +StdEnvVars
-    </Directory>
-    BrowserMatch "MSIE [2-6]" \
-        nokeepalive ssl-unclean-shutdown \
-        downgrade-1.0 force-response-1.0
-    # MSIE 7 and newer should be able to use keepalive
-    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
 </VirtualHost>

--- a/etc/apache2/sites-available/instance-private-with-httpsonly.template
+++ b/etc/apache2/sites-available/instance-private-with-httpsonly.template
@@ -17,25 +17,17 @@
 
     # No security for gadgets
     <ProxyMatch "^.*/(eXoGadgetServer|exo-gadget-resources|rest|.*Resources)/.*$">
-        Order allow,deny
-        Allow from all
-        Satisfy any
+        Require all granted
     </ProxyMatch>
 
     # No security for chat local access
     <ProxyMatch "^.*/chatServer/.*$">
-        Order deny,allow
-        Deny from all
-        Allow from exoplatform.org
-        Satisfy any
+        Require host exoplatform.org
     </ProxyMatch>
 
     # Everything else is secured
     <Proxy *>
         <IfModule authnz_crowd_module>
-            Order deny,allow
-            Allow from all
-
             AuthName "eXo Employees only"
             AuthType Basic
             AuthBasicProvider crowd
@@ -74,26 +66,12 @@
     SSLEngine             on
     SSLCertificateFile       ${INSTANCE_SSL_CERTIFICATE_FILE}
     SSLCertificateKeyFile    ${INSTANCE_SSL_CERTIFICATE_KEY_FILE}
-    SSLCertificateChainFile  ${INSTANCE_SSL_CERTIFICATE_CHAIN_FILE}
     SSLVerifyClient None
 
-    # configuration du SSL
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
     SSLHonorCipherOrder     on
 
     Header always set Strict-Transport-Security "max-age=63072000"
-
-    <FilesMatch "\.(cgi|shtml|phtml|php)$">
-        SSLOptions +StdEnvVars
-    </FilesMatch>
-    <Directory /usr/lib/cgi-bin>
-        SSLOptions +StdEnvVars
-    </Directory>
-    BrowserMatch "MSIE [2-6]" \
-        nokeepalive ssl-unclean-shutdown \
-        downgrade-1.0 force-response-1.0
-    # MSIE 7 and newer should be able to use keepalive
-    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
 </VirtualHost>

--- a/etc/apache2/sites-available/instance-private.template
+++ b/etc/apache2/sites-available/instance-private.template
@@ -6,25 +6,17 @@
 
     # No security for gadgets
     <ProxyMatch "^.*/(eXoGadgetServer|exo-gadget-resources|rest|.*Resources)/.*$">
-        Order allow,deny
-        Allow from all
-        Satisfy any
+        Require all granted
     </ProxyMatch>
 
     # No security for chat local access
     <ProxyMatch "^.*/chatServer/.*$">
-        Order deny,allow
-        Deny from all
-        Allow from exoplatform.org
-        Satisfy any
+        Require host exoplatform.org
     </ProxyMatch>
 
     # Everything else is secured
     <Proxy *>
         <IfModule authnz_crowd_module>
-            Order deny,allow
-            Allow from all
-
             AuthName "eXo Employees only"
             AuthType Basic
             AuthBasicProvider crowd

--- a/etc/apache2/sites-available/instance-public-with-https.template
+++ b/etc/apache2/sites-available/instance-public-with-https.template
@@ -156,26 +156,12 @@
     SSLEngine             on
     SSLCertificateFile       ${INSTANCE_SSL_CERTIFICATE_FILE}
     SSLCertificateKeyFile    ${INSTANCE_SSL_CERTIFICATE_KEY_FILE}
-    SSLCertificateChainFile  ${INSTANCE_SSL_CERTIFICATE_CHAIN_FILE}
     SSLVerifyClient None
 
-    # configuration du SSL
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
     SSLHonorCipherOrder     on
 
     Header always set Strict-Transport-Security "max-age=63072000"
-
-    <FilesMatch "\.(cgi|shtml|phtml|php)$">
-        SSLOptions +StdEnvVars
-    </FilesMatch>
-    <Directory /usr/lib/cgi-bin>
-        SSLOptions +StdEnvVars
-    </Directory>
-    BrowserMatch "MSIE [2-6]" \
-        nokeepalive ssl-unclean-shutdown \
-        downgrade-1.0 force-response-1.0
-    # MSIE 7 and newer should be able to use keepalive
-    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
 </VirtualHost>

--- a/etc/apache2/sites-available/instance-public-with-httpsonly.template
+++ b/etc/apache2/sites-available/instance-public-with-httpsonly.template
@@ -136,25 +136,11 @@
     SSLEngine             on
     SSLCertificateFile       ${INSTANCE_SSL_CERTIFICATE_FILE}
     SSLCertificateKeyFile    ${INSTANCE_SSL_CERTIFICATE_KEY_FILE}
-    SSLCertificateChainFile  ${INSTANCE_SSL_CERTIFICATE_CHAIN_FILE}
     SSLVerifyClient None
 
-    # configuration du SSL
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
     SSLHonorCipherOrder     on
 
     Header always set Strict-Transport-Security "max-age=63072000"
-    
-    <FilesMatch "\.(cgi|shtml|phtml|php)$">
-        SSLOptions +StdEnvVars
-    </FilesMatch>
-    <Directory /usr/lib/cgi-bin>
-        SSLOptions +StdEnvVars
-    </Directory>
-    BrowserMatch "MSIE [2-6]" \
-        nokeepalive ssl-unclean-shutdown \
-        downgrade-1.0 force-response-1.0
-    # MSIE 7 and newer should be able to use keepalive
-    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 </VirtualHost>


### PR DESCRIPTION
- Replace Order/Allow/Deny/Satisfy (Apache 2.2) with Require directives (2.4)
- Remove deprecated SSLCertificateChainFile (merge into cert file per 2.4.8+)
- Remove dead BrowserMatch MSIE rules (Internet Explorer EOL)
- Remove disablereuse/flushpackets WebSocket workarounds (needed only < 2.4.13)
- Fix orphaned Options directive in frontend.include.template
- All configs validated with httpd -t on httpd:2.4.58 Docker image